### PR TITLE
Crontab and deploy work

### DIFF
--- a/README.md
+++ b/README.md
@@ -5,12 +5,12 @@
 A lightweight system for publishing analytics data from Google Analytics profiles.
 
 
-### Setup
+### Installing
 
-* You'll need [Node](http://nodejs.org). Then install Node dependencies:
+* Install through npm:
 
 ```bash
-npm install
+npm install -g analytics-reporter
 ```
 
 * [Create an API service account](https://developers.google.com/accounts/docs/OAuth2ServiceAccount) in the Google developer dashboard.

--- a/analytics.js
+++ b/analytics.js
@@ -45,8 +45,7 @@ var Analytics = {
         if (report.query.filters)
             query.filters = report.query.filters.join(",");
 
-        if (report.query['max-results'])
-            query['max-results'] = report.query['max-results'];
+        query['max-results'] = report.query['max-results'] || 1000;
 
         if (report.query['sort'])
             query['sort'] = report.query['sort'];

--- a/analytics.js
+++ b/analytics.js
@@ -18,7 +18,8 @@ var jwt = new googleapis.auth.JWT(
 
 
 // The reports we want to run.
-var reports = JSON.parse(fs.readFileSync(path.join(__dirname, "reports.json"))).reports;
+var reports_path = path.join(__dirname, "reports.json");
+var reports = JSON.parse(fs.readFileSync(reports_path)).reports;
 var by_name = {};
 for (var i=0; i<reports.length; i++)
     by_name[reports[i].name] = reports[i];

--- a/bin/analytics
+++ b/bin/analytics
@@ -16,6 +16,7 @@
 var Analytics = require("../analytics"),
     config = require("../config"),
     fs = require("fs"),
+    path = require('path'),
     async = require("async");
 
 
@@ -66,7 +67,7 @@ var run = function(options) {
         if (options.publish)
           publish(report.name, json, options, written);
         else if (options.output && (typeof(options.output) == "string"))
-          fs.writeFile(options.output + "/" + report.name + ".json", json, written);
+          fs.writeFile(path.join(options.output, (report.name + ".json")), json, written);
         else {
           // could be split on \n\n
           console.log(json + "\n");

--- a/bin/analytics
+++ b/bin/analytics
@@ -50,14 +50,14 @@ var run = function(options) {
 
     if (options.debug) console.log("\n[" + report.name + "] Fetching...");
     Analytics.query(report, function(err, data) {
-        if (err) return console.log("ERROR: " + JSON.stringify(err));
+        if (err) return console.log("ERROR AFTER QUERYING: " + JSON.stringify(err));
 
         if (options.debug) console.log("[" + report.name + "] Saving report data...");
         var json = JSON.stringify(data, null, 2);
 
         var written = function(err) {
           if (err)
-            console.error("ERROR: " + JSON.stringify(err));
+            console.error("ERROR AFTER WRITING: " + JSON.stringify(err));
           else if (options.debug)
             console.log("[" + report.name + "] Done.");
           done();

--- a/deploy/crontab
+++ b/deploy/crontab
@@ -1,0 +1,11 @@
+# Run all reports every day soon after midnight. Server uses UTC.
+
+# Contents of daily.sh:
+
+# #!/bin/bash
+#
+# export PATH=$PATH:/usr/local/bin
+# source $HOME/.bashrc
+# analytics --publish
+
+10 5 * * * /home/analytics/daily.sh > /home/analytics/analytics.log 2>&1

--- a/reports.json
+++ b/reports.json
@@ -37,8 +37,8 @@
         "metrics": ["ga:sessions"],
         "start-date": "7daysAgo",
         "end-date": "yesterday",
+        "filters": ["ga:sessions>50"],
         "sort": "ga:date"
-
       },
       "meta": {
         "names": "Operating Systems",
@@ -122,7 +122,7 @@
       },
       "meta": {
         "name": "Top Sources",
-        "description": "Breakdown of top 50 sources in terms of sessions for the last week",
+        "description": "Breakdown of top 50 sources in terms of sessions for the last week.",
         "documentation": "http://www.usa.gov/performance"
       }
     },
@@ -153,7 +153,7 @@
         "filters": ["ga:browser==Internet Explorer"]
       },
       "meta": {
-        "name": "Internet Explorer"
+        "name": "Internet Explorer",
         "description": "Weekly visits from Internet Explorer users broken down by version for all .gov sites tracked by the U.S. federal government's Digital Analytics Program.",
         "documentation": "http://www.usa.gov/performance"
       }

--- a/reports.json
+++ b/reports.json
@@ -10,6 +10,7 @@
         "sort": "ga:date"
       },
       "meta": {
+        "name": "Users",
         "description": "Weekly visitors by day to all .gov sites tracked by the U.S. federal government's Digital Analytics Program.",
         "documentation": "http://www.usa.gov/performance"
       }
@@ -24,6 +25,7 @@
         "sort": "ga:date"
       },
       "meta": {
+        "name": "Devices",
         "description": "Weekly desktop/mobile/tablet visits by day for all .gov sites tracked by the U.S. federal government's Digital Analytics Program.",
         "documentation": "http://www.usa.gov/performance"
       }
@@ -39,6 +41,7 @@
 
       },
       "meta": {
+        "names": "Operating Systems",
         "description": "Weekly visits, broken down by operating system and date, for all .gov sites tracked by the U.S. federal government's Digital Analytics Program.",
         "documentation": "http://www.usa.gov/performance"
       }
@@ -54,6 +57,7 @@
         "sort": "ga:date"
       },
       "meta": {
+        "names": "Windows",
         "description": "Weekly visits from Windows users, broken down by operating system version and date, for all .gov sites tracked by the U.S. federal government's Digital Analytics Program.",
         "documentation": "http://www.usa.gov/performance"
       }
@@ -69,6 +73,7 @@
         "max-results": "20"
       },
       "meta": {
+        "name": "Top Pages (7 Days)",
         "description": "Last week's top 20 pages in terms of sessions for all .gov sites tracked by the U.S. federal government's Digital Analytics Program.",
         "documentation": "http://www.usa.gov/performance"
       }
@@ -84,6 +89,7 @@
         "max-results": "20"
       },
       "meta": {
+        "name": "Top Pages (30 Days)",
         "description": "Last 30 day's top 20 pages in terms of sessions for all .gov sites tracked by the U.S. federal government's Digital Analytics Program.",
         "documentation": "http://www.usa.gov/performance"
       }
@@ -99,6 +105,7 @@
         "max-results": "20"
       },
       "meta": {
+        "name": "Top Pages (90 Days)",
         "description": "Last 90 day's top 20 pages in terms of sessions for all .gov sites tracked by the U.S. federal government's Digital Analytics Program.",
         "documentation": "http://www.usa.gov/performance"
       }
@@ -114,6 +121,7 @@
         "max-results": "50"
       },
       "meta": {
+        "name": "Top Sources",
         "description": "Breakdown of top 50 sources in terms of sessions for the last week",
         "documentation": "http://www.usa.gov/performance"
       }
@@ -129,6 +137,7 @@
         "filters": ["ga:sessions>50"]
       },
       "meta": {
+        "name": "Browsers",
         "description": "Weekly visits broken down by browser for all .gov sites tracked by the U.S. federal government's Digital Analytics Program.",
         "documentation": "http://www.usa.gov/performance"
       }
@@ -144,6 +153,7 @@
         "filters": ["ga:browser==Internet Explorer"]
       },
       "meta": {
+        "name": "Internet Explorer"
         "description": "Weekly visits from Internet Explorer users broken down by version for all .gov sites tracked by the U.S. federal government's Digital Analytics Program.",
         "documentation": "http://www.usa.gov/performance"
       }


### PR DESCRIPTION
This adds the crontab (with inline commented mini-shell-script) that we're using on the server right now. It's super basic. It does not get packaged with the npm module -- it's expected that users figure out their own deploy strategy.

This also makes the `--output` command more flexible about trailing slashes.

Downstream from #47. Fixes #14.