### PR TITLE
Adds option to omit individual data points

### DIFF
--- a/bin/analytics
+++ b/bin/analytics
@@ -10,6 +10,8 @@
  * --output: Output to a directory.
  * --publish: Publish to an S3 bucket.
  * --only: only run one report.
+ * --head: Totals only (omit individual data points). Only applies to JSON.
+ * --csv: CSV instead of JSON.
  * --debug: print debug details on STDOUT
  */
 
@@ -68,8 +70,10 @@ var run = function(options) {
         }
 
         // JSON
-        else
+        else {
+          if (options.head) delete data.data;
           writeReport(name, JSON.stringify(data, null, 2), ".json", done);
+        }
     });
   };
 


### PR DESCRIPTION
This adds a `--head` option, which deletes the `data` object from the JSON before serializing it. This allows us to create lightweight JSON for potentially large, expensive reports. While it's not as helpful for bulk data or detailed analysis, it's definitely what we'll need for a dashboard that will be making a bunch of dynamic calls.

So the output process (for daily reports) is starting to look like this:

```bash
analytics --head --publish
analytics --publish
analytics --csv --publish
```