### PR TITLE
Extend and refine the reports we're collecting

### DIFF
--- a/analytics.js
+++ b/analytics.js
@@ -45,7 +45,7 @@ var Analytics = {
         if (report.query.filters)
             query.filters = report.query.filters.join(",");
 
-        query['max-results'] = report.query['max-results'] || 1000;
+        query['max-results'] = report.query['max-results'] || 10000;
 
         if (report.query['sort'])
             query['sort'] = report.query['sort'];
@@ -231,6 +231,10 @@ var Analytics = {
                 result.totals.ie_version[version] += parseInt(result.data[i].visits);
             }
         }
+
+        // awkward, but the data *are* the totals here, we don't keep data points
+        if (report.name == "sources")
+            result.totals = data;
 
         // presumably we're organizing these by date
         if (result.data[0].date) {

--- a/analytics.js
+++ b/analytics.js
@@ -214,7 +214,7 @@ var Analytics = {
             }
         }
 
-        if (report.name == "ie-version") {
+        if (report.name == "ie") {
             // initialize all cared-about versions to 0
             result.totals.ie_version = {};
             for (var i=0; i<Analytics.ie_versions.length; i++)

--- a/reports.json
+++ b/reports.json
@@ -1,33 +1,17 @@
 {
   "reports": [
     {
-      "name": "users",
-      "query": {
-        "dimensions": ["ga:date"],
-        "metrics": ["ga:users"],
-        "start-date" : "7daysAgo",
-        "end-date" : "yesterday",
-        "sort": "ga:date"
-      },
-      "meta": {
-        "name": "Users",
-        "description": "Weekly visitors by day to all .gov sites tracked by the U.S. federal government's Digital Analytics Program.",
-        "documentation": "http://www.usa.gov/performance"
-      }
-    },
-    {
       "name": "devices",
       "query": {
         "dimensions": ["ga:date" ,"ga:deviceCategory"],
         "metrics": ["ga:sessions"],
-        "start-date": "7daysAgo",
+        "start-date": "90daysAgo",
         "end-date": "yesterday",
         "sort": "ga:date"
       },
       "meta": {
         "name": "Devices",
-        "description": "Weekly desktop/mobile/tablet visits by day for all .gov sites tracked by the U.S. federal government's Digital Analytics Program.",
-        "documentation": "http://www.usa.gov/performance"
+        "description": "Weekly desktop/mobile/tablet visits by day for all .gov sites tracked by the U.S. federal government's Digital Analytics Program."
       }
     },
     {
@@ -35,15 +19,14 @@
       "query": {
         "dimensions": ["ga:date" ,"ga:operatingSystem"],
         "metrics": ["ga:sessions"],
-        "start-date": "7daysAgo",
+        "start-date": "90daysAgo",
         "end-date": "yesterday",
-        "filters": ["ga:sessions>50"],
+        "filters": ["ga:sessions>1000"],
         "sort": "ga:date"
       },
       "meta": {
         "names": "Operating Systems",
-        "description": "Weekly visits, broken down by operating system and date, for all .gov sites tracked by the U.S. federal government's Digital Analytics Program.",
-        "documentation": "http://www.usa.gov/performance"
+        "description": "Weekly visits, broken down by operating system and date, for all .gov sites tracked by the U.S. federal government's Digital Analytics Program."
       }
     },
     {
@@ -51,18 +34,47 @@
       "query": {
         "dimensions": ["ga:date" ,"ga:operatingSystemVersion"],
         "metrics": ["ga:sessions"],
-        "start-date": "7daysAgo",
+        "start-date": "90daysAgo",
         "end-date": "yesterday",
-        "filters": ["ga:operatingSystem==Windows"],
+        "filters": ["ga:operatingSystem==Windows;ga:sessions>1000"],
         "sort": "ga:date"
       },
       "meta": {
         "names": "Windows",
-        "description": "Weekly visits from Windows users, broken down by operating system version and date, for all .gov sites tracked by the U.S. federal government's Digital Analytics Program.",
-        "documentation": "http://www.usa.gov/performance"
+        "description": "Weekly visits from Windows users, broken down by operating system version and date, for all .gov sites tracked by the U.S. federal government's Digital Analytics Program."
       }
     },
-      {
+    {
+      "name": "browsers",
+      "query": {
+        "dimensions": ["ga:date" ,"ga:browser"],
+        "metrics": ["ga:sessions"],
+        "start-date": "90daysAgo",
+        "end-date": "yesterday",
+        "sort": "ga:date,-ga:sessions",
+        "filters": ["ga:sessions>1000"]
+      },
+      "meta": {
+        "name": "Browsers",
+        "description": "Weekly visits broken down by browser for all .gov sites tracked by the U.S. federal government's Digital Analytics Program."
+      }
+    },
+    {
+      "name": "ie",
+      "query": {
+        "dimensions": ["ga:date","ga:browserVersion"],
+        "metrics": ["ga:sessions"],
+        "start-date": "90daysAgo",
+        "end-date": "yesterday",
+        "sort": "ga:date,-ga:sessions",
+        "filters": ["ga:browser==Internet Explorer;ga:sessions>1000"]
+      },
+      "meta": {
+        "name": "Internet Explorer",
+        "description": "Weekly visits from Internet Explorer users broken down by version for all .gov sites tracked by the U.S. federal government's Digital Analytics Program."
+      }
+    },
+    {
       "name": "top-pages-7-days",
       "query": {
         "dimensions": ["ga:hostname"],
@@ -74,8 +86,7 @@
       },
       "meta": {
         "name": "Top Pages (7 Days)",
-        "description": "Last week's top 20 pages in terms of sessions for all .gov sites tracked by the U.S. federal government's Digital Analytics Program.",
-        "documentation": "http://www.usa.gov/performance"
+        "description": "Last week's top 20 pages in terms of sessions for all .gov sites tracked by the U.S. federal government's Digital Analytics Program."
       }
     },
     {
@@ -90,8 +101,7 @@
       },
       "meta": {
         "name": "Top Pages (30 Days)",
-        "description": "Last 30 day's top 20 pages in terms of sessions for all .gov sites tracked by the U.S. federal government's Digital Analytics Program.",
-        "documentation": "http://www.usa.gov/performance"
+        "description": "Last 30 day's top 20 pages in terms of sessions for all .gov sites tracked by the U.S. federal government's Digital Analytics Program."
       }
     },
     {
@@ -106,8 +116,7 @@
       },
       "meta": {
         "name": "Top Pages (90 Days)",
-        "description": "Last 90 day's top 20 pages in terms of sessions for all .gov sites tracked by the U.S. federal government's Digital Analytics Program.",
-        "documentation": "http://www.usa.gov/performance"
+        "description": "Last 90 day's top 20 pages in terms of sessions for all .gov sites tracked by the U.S. federal government's Digital Analytics Program."
       }
     },
     {
@@ -115,49 +124,15 @@
       "query": {
         "dimensions": ["ga:source"],
         "metrics": ["ga:sessions"],
-        "start-date": "7daysAgo",
+        "start-date": "90daysAgo",
         "end-date": "yesterday",
         "sort": "-ga:sessions",
         "max-results": "50"
       },
       "meta": {
         "name": "Top Sources",
-        "description": "Breakdown of top 50 sources in terms of sessions for the last week.",
-        "documentation": "http://www.usa.gov/performance"
-      }
-    },
-    {
-      "name": "browsers",
-      "query": {
-        "dimensions": ["ga:date" ,"ga:browser"],
-        "metrics": ["ga:sessions"],
-        "start-date": "7daysAgo",
-        "end-date": "yesterday",
-        "sort": "ga:date,-ga:sessions",
-        "filters": ["ga:sessions>50"]
-      },
-      "meta": {
-        "name": "Browsers",
-        "description": "Weekly visits broken down by browser for all .gov sites tracked by the U.S. federal government's Digital Analytics Program.",
-        "documentation": "http://www.usa.gov/performance"
-      }
-    },
-    {
-      "name": "ie",
-      "query": {
-        "dimensions": ["ga:date","ga:browserVersion"],
-        "metrics": ["ga:sessions"],
-        "start-date": "7daysAgo",
-        "end-date": "yesterday",
-        "sort": "ga:date,-ga:sessions",
-        "filters": ["ga:browser==Internet Explorer"]
-      },
-      "meta": {
-        "name": "Internet Explorer",
-        "description": "Weekly visits from Internet Explorer users broken down by version for all .gov sites tracked by the U.S. federal government's Digital Analytics Program.",
-        "documentation": "http://www.usa.gov/performance"
+        "description": "Breakdown of top 50 sources in terms of sessions for the last 90 days."
       }
     }
-
   ]
 }


### PR DESCRIPTION
This extends the `devices`, `sources`, `browsers`, `ie`, `os`, and `windows` reports to use 90 day windows. Where necessary, it limits matching candidates to those who have greater than 1000 sessions (~0.0001% of the 1B+ sessions the DAP receives in a 90-day window). The threshold could probably be raised substantially, but this keeps the reports well below the maximum of 10,000 distinct results over 90 days.

It also increases the default `max-results` field for every report to `10000`, instead of `1000`.

Fixes #42.