### PR TITLE
Real time report of active users onsite

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -7,3 +7,4 @@
 *.json
 *.csv
 /data
+todo.txt

--- a/bin/analytics
+++ b/bin/analytics
@@ -12,6 +12,7 @@
  * --only: only run one report.
  * --head: Totals only (omit individual data points). Only applies to JSON.
  * --csv: CSV instead of JSON.
+ * --frequency: Limit to reports with this 'frequency' value.
  * --debug: print debug details on STDOUT
  */
 
@@ -49,14 +50,27 @@ var run = function(options) {
   if (options.verbose) options.debug = options.verbose;
 
   // can be overridden to only do one report
-  var names = options.only ? [options.only] : Object.keys(Analytics.reports);
+  var names;
+  if (options.only)
+    names = [options.only];
+  else if (options.frequency) {
+    names = [];
+    var all = Object.keys(Analytics.reports);
+    for (var i=0; i<all.length; i++) {
+      if (Analytics.reports[all[i]].frequency == options.frequency)
+        names.push(all[i]);
+    }
+  }
+
+  else
+    names = Object.keys(Analytics.reports);
 
   var eachReport = function(name, done) {
     var report = Analytics.reports[name];
 
     if (options.debug) console.log("\n[" + report.name + "] Fetching...");
     Analytics.query(report, function(err, data) {
-        if (err) return console.log("ERROR AFTER QUERYING: " + JSON.stringify(err));
+        if (err) return console.log("ERROR AFTER QUERYING: " + err);
 
         if (options.debug) console.log("[" + report.name + "] Saving report data...");
 

--- a/deploy/crontab
+++ b/deploy/crontab
@@ -1,11 +1,23 @@
 # Run all reports every day soon after midnight. Server uses UTC.
 
+################################
 # Contents of daily.sh:
 
 # #!/bin/bash
 #
 # export PATH=$PATH:/usr/local/bin
 # source $HOME/.bashrc
-# analytics --publish
+# analytics --publish --frequency=daily
+
+#############################
+# Contents of realtime.sh:
+
+# #!/bin/bash
+#
+# export PATH=$PATH:/usr/local/bin
+# source $HOME/.bashrc
+# analytics --publish --frequency=realtime
+
 
 10 5 * * * /home/analytics/daily.sh > /home/analytics/analytics.log 2>&1
+*/1 * * * * /home/analytics/realtime.sh > /home/analytics/analytics-realtime.log 2>&1

--- a/reports.json
+++ b/reports.json
@@ -1,7 +1,19 @@
 {
   "reports": [
     {
+      "name": "realtime",
+      "frequency": "realtime",
+      "query": {
+        "metrics": ["rt:activeUsers"]
+      },
+      "meta": {
+        "name": "Active Users Right Now",
+        "description": "Number of users currently visiting all sites tracked by the U.S. federal government's Digital Analytics Program."
+      }
+    },
+    {
       "name": "devices",
+      "frequency": "daily",
       "query": {
         "dimensions": ["ga:date" ,"ga:deviceCategory"],
         "metrics": ["ga:sessions"],
@@ -16,6 +28,7 @@
     },
     {
       "name": "os",
+      "frequency": "daily",
       "query": {
         "dimensions": ["ga:date" ,"ga:operatingSystem"],
         "metrics": ["ga:sessions"],
@@ -31,6 +44,7 @@
     },
     {
       "name": "windows",
+      "frequency": "daily",
       "query": {
         "dimensions": ["ga:date" ,"ga:operatingSystemVersion"],
         "metrics": ["ga:sessions"],
@@ -46,6 +60,7 @@
     },
     {
       "name": "browsers",
+      "frequency": "daily",
       "query": {
         "dimensions": ["ga:date" ,"ga:browser"],
         "metrics": ["ga:sessions"],
@@ -61,6 +76,7 @@
     },
     {
       "name": "ie",
+      "frequency": "daily",
       "query": {
         "dimensions": ["ga:date","ga:browserVersion"],
         "metrics": ["ga:sessions"],
@@ -76,6 +92,7 @@
     },
     {
       "name": "top-pages-7-days",
+      "frequency": "daily",
       "query": {
         "dimensions": ["ga:hostname"],
         "metrics": ["ga:sessions"],
@@ -91,6 +108,7 @@
     },
     {
       "name": "top-pages-30-days",
+      "frequency": "daily",
       "query": {
         "dimensions": ["ga:hostname"],
         "metrics": ["ga:sessions"],
@@ -106,6 +124,7 @@
     },
     {
       "name": "top-pages-90-days",
+      "frequency": "daily",
       "query": {
         "dimensions": ["ga:hostname"],
         "metrics": ["ga:sessions"],
@@ -121,6 +140,7 @@
     },
     {
       "name": "sources",
+      "frequency": "daily",
       "query": {
         "dimensions": ["ga:source"],
         "metrics": ["ga:sessions"],


### PR DESCRIPTION
This adds a report that uses the [Google Analytics Real Time Reporting API](https://developers.google.com/analytics/devguides/reporting/realtime/v3/) to fetch active users currently on site.

```json
{
  "name": "realtime",
  "query": {
    "metrics": [
      "rt:activeUsers"
    ]
  },
  "meta": {
    "name": "Active Users Right Now",
    "description": "Number of users currently visiting all sites tracked by the U.S. federal government's Digital Analytics Program."
  },
  "data": [
    {
      "active_visitors": "24619"
    }
  ],
  "totals": [
    {
      "active_visitors": "24619"
    }
  ]
}
```

It adds a `frequency` field to each report in `reports.json`. If `frequency` is set to `realtime`, then the API call is made to the Real Time Reporting API instead of the Core Reporting API. I made the query assembling code more flexible to accommodate a report that lacks a start date, end date, or any dimensions. (In the Real Time API, only metrics are required.) 

The `rt:activeUsers` field is mapped to an `active_visitors` field in the resulting JSON. The `totals` field is just a copy of the `data` field, so that even requests with `--head` will return the right data.

Additionally, the `analytics` command now has a `--frequency` flag, which will cause the reports to be filtered to only those with a matching `frequency` field. 

Finally, I updated the crontab to add a line for the real-time report (every 1 minute, as discussed in https://github.com/18F/analytics-reporter/issues/32#issuecomment-69536016) and made a separate `realtime.sh` script. So the crontab is essentially bifurcated now.

I also fixed a couple bugs:

* The `totals` field was not copying the correct data over for the `sources` report. The `realtime` report uses the same approach, which is how I caught the bug.
* Query errors were not being printed out correctly in the `analytics` command.

Fixes #32.