### PR TITLE
Realtime report for top pages

### DIFF
--- a/analytics.js
+++ b/analytics.js
@@ -91,6 +91,8 @@ var Analytics = {
         "ga:date": "date",
         "ga:users": "visitors",
         "rt:activeUsers": "active_visitors",
+        "rt:pagePath": "page",
+        "rt:pageTitle": "page_title",
         "ga:sessions": "visits",
         "ga:deviceCategory": "device",
         "ga:operatingSystem": "os",
@@ -247,9 +249,12 @@ var Analytics = {
             }
         }
 
-        // awkward, but the data *are* the totals here, we don't keep data points
-        if (report.name == "sources" || report.name == "realtime")
+        // awkward, but the data *are* the totals here, needs to be in --head
+        if (report.name == "sources"
+            || report.name == "realtime"
+            || (report.name.indexOf("top-pages") >= 0)) {
             result.totals = result.data;
+        }
 
         // presumably we're organizing these by date
         if (result.data[0].date) {

--- a/reports.json
+++ b/reports.json
@@ -91,6 +91,20 @@
       }
     },
     {
+      "name": "top-pages-realtime",
+      "frequency": "realtime",
+      "query": {
+        "dimensions": ["rt:pagePath", "rt:pageTitle"],
+        "metrics": ["rt:activeUsers"],
+        "sort": "-rt:activeUsers",
+        "max-results": "20"
+      },
+      "meta": {
+        "name": "Top Pages (7 Days)",
+        "description": "Last week's top 20 pages in terms of sessions for all .gov sites tracked by the U.S. federal government's Digital Analytics Program."
+      }
+    },
+    {
       "name": "top-pages-7-days",
       "frequency": "daily",
       "query": {


### PR DESCRIPTION
This adds a `top-pages-realtime` report that gets page URL and title information from the Google Analytics Real Time API:

```javascript
{
  "name": "top-pages-realtime",
  "query": {
    "dimensions": [
      "rt:pagePath",
      "rt:pageTitle"
    ],
    "metrics": [
      "rt:activeUsers"
    ],
    "sort": "-rt:activeUsers",
    "max-results": "20"
  },
  "meta": {
    "name": "Top Pages (7 Days)",
    "description": "Last week's top 20 pages in terms of sessions for all .gov sites tracked by the U.S. federal government's Digital Analytics Program."
  },
  "data": [
    {
      "page": "ftc.gov/enforcement/cases-proceedings/refunds/att-refunds",
      "page_title": "AT&T Refunds | Federal Trade Commission",
      "active_visitors": "1741"
    },
    {
      "page": "weather.gov/",
      "page_title": "National Weather Service",
      "active_visitors": "1728"
    },
    // ...
  ]
}
```