### PR TITLE
Different approach to slimming verbose reports

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -6,5 +6,6 @@
 /.env
 *.json
 *.csv
+*.gz
 /data
 todo.txt

--- a/README.md
+++ b/README.md
@@ -136,10 +136,10 @@ analytics --publish
 analytics --only devices
 ```
 
-* `--head` - Totals only (omit individual data points). Only applies to JSON.
+* `--slim` -Where supported, use totals only (omit the `data` array). Only applies to JSON, and reports where `"slim": true`.
 
 ```bash
-analytics --only devices --head
+analytics --only devices --slim
 ```
 
 * `--csv` - Gives you CSV instead of JSON.

--- a/analytics.js
+++ b/analytics.js
@@ -250,16 +250,6 @@ var Analytics = {
             }
         }
 
-        // awkward, but the data *are* the totals here, needs to be in --head
-        if (report.name == "realtime")
-            result.totals = result.data[0];
-
-        // realtime uses pages, multi-day uses domains
-        if (report.name == "top-pages-realtime")
-            result.totals = {pages: result.data}
-        else if (report.name.indexOf("top-pages") >= 0)
-            result.totals = {domains: result.data}
-
         // presumably we're organizing these by date
         if (result.data[0].date) {
             result.totals.start_date = result.data[0].date;

--- a/bin/analytics
+++ b/bin/analytics
@@ -10,7 +10,8 @@
  * --output: Output to a directory.
  * --publish: Publish to an S3 bucket.
  * --only: only run one report.
- * --head: Totals only (omit individual data points). Only applies to JSON.
+ * --slim: Where supported, use totals only (omit the `data` array).
+ *         Only applies to JSON, and reports where "slim": true.
  * --csv: CSV instead of JSON.
  * --frequency: Limit to reports with this 'frequency' value.
  * --debug: print debug details on STDOUT
@@ -85,7 +86,9 @@ var run = function(options) {
 
         // JSON
         else {
-          if (options.head) delete data.data;
+          // some reports can be slimmed down for direct rendering
+          if (options.slim && report.slim) delete data.data;
+
           writeReport(name, JSON.stringify(data, null, 2), ".json", done);
         }
     });

--- a/deploy/crontab
+++ b/deploy/crontab
@@ -7,7 +7,16 @@
 #
 # export PATH=$PATH:/usr/local/bin
 # source $HOME/.bashrc
-# analytics --publish --frequency=daily
+# analytics --publish --frequency=daily --slim --verbose
+
+################################
+# Contents of hourly.sh:
+
+# #!/bin/bash
+#
+# export PATH=$PATH:/usr/local/bin
+# source $HOME/.bashrc
+# analytics --publish --frequency=hourly --slim --verbose
 
 #############################
 # Contents of realtime.sh:
@@ -16,8 +25,13 @@
 #
 # export PATH=$PATH:/usr/local/bin
 # source $HOME/.bashrc
-# analytics --publish --frequency=realtime
+# analytics --publish --frequency=realtime --slim --verbose
 
+# most reports
+10 5 * * * /home/analytics/daily.sh > /home/analytics/logs/daily.log 2>&1
 
-10 5 * * * /home/analytics/daily.sh > /home/analytics/analytics.log 2>&1
-*/1 * * * * /home/analytics/realtime.sh > /home/analytics/analytics-realtime.log 2>&1
+# a couple hourly reports
+1 * * * * /home/analytics/hourly.sh > /home/analytics/logs/hourly.log 2>&1
+
+# realtime reports
+*/1 * * * * /home/analytics/realtime.sh > /home/analytics/logs/realtime.log 2>&1

--- a/reports.json
+++ b/reports.json
@@ -42,6 +42,7 @@
     {
       "name": "devices",
       "frequency": "daily",
+      "slim": true,
       "query": {
         "dimensions": ["ga:date" ,"ga:deviceCategory"],
         "metrics": ["ga:sessions"],
@@ -57,6 +58,7 @@
     {
       "name": "os",
       "frequency": "daily",
+      "slim": true,
       "query": {
         "dimensions": ["ga:date" ,"ga:operatingSystem"],
         "metrics": ["ga:sessions"],
@@ -73,6 +75,7 @@
     {
       "name": "windows",
       "frequency": "daily",
+      "slim": true,
       "query": {
         "dimensions": ["ga:date" ,"ga:operatingSystemVersion"],
         "metrics": ["ga:sessions"],
@@ -89,6 +92,7 @@
     {
       "name": "browsers",
       "frequency": "daily",
+      "slim": true,
       "query": {
         "dimensions": ["ga:date" ,"ga:browser"],
         "metrics": ["ga:sessions"],
@@ -105,6 +109,7 @@
     {
       "name": "ie",
       "frequency": "daily",
+      "slim": true,
       "query": {
         "dimensions": ["ga:date","ga:browserVersion"],
         "metrics": ["ga:sessions"],


### PR DESCRIPTION
This renames `--head` to `--slim`, and makes it only apply to reports which advertise support for it with `"slim": true`. When `--slim` is given and a report is processed that supports it, the `data` field is deleted.

I've also removed some of the awkward totals-copying code, so now we don't needlessly duplicate data between `data` and `totals`. The price, however, is that now some charts that render this data will use the `data` field, and some will use the `totals` field.

This also updates our crontab and associated runners to be more consistent, and the server has been brought up to date with them. I would _love_ to get away from using `cron`.