### PR TITLE
Re-add 'users' report for top-line number

### DIFF
--- a/analytics.js
+++ b/analytics.js
@@ -167,10 +167,10 @@ var Analytics = {
             for (var i=0; i<result.data.length; i++)
                 result.totals.visitors += parseInt(result.data[i].visitors);
         }
-        if ("sessions" in result.data[0]) {
-            result.totals.sessions = 0;
+        if ("visits" in result.data[0]) {
+            result.totals.visits = 0;
             for (var i=0; i<result.data.length; i++)
-                result.totals.sessions += parseInt(result.data[i].sessions);
+                result.totals.visits += parseInt(result.data[i].visits);
         }
 
         if (report.name == "devices") {

--- a/reports.json
+++ b/reports.json
@@ -40,6 +40,22 @@
       }
     },
     {
+      "name": "users",
+      "frequency": "daily",
+      "slim": true,
+      "query": {
+        "dimensions": ["ga:date"],
+        "metrics": ["ga:sessions"],
+        "start-date": "90daysAgo",
+        "end-date": "yesterday",
+        "sort": "ga:date"
+      },
+      "meta": {
+        "name": "Visitors",
+        "description": "90 days of visits for all .gov sites tracked by the U.S. federal government's Digital Analytics Program."
+      }
+    },
+    {
       "name": "devices",
       "frequency": "daily",
       "slim": true,
@@ -52,7 +68,7 @@
       },
       "meta": {
         "name": "Devices",
-        "description": "Weekly desktop/mobile/tablet visits by day for all .gov sites tracked by the U.S. federal government's Digital Analytics Program."
+        "description": "90 days of desktop/mobile/tablet visits for all .gov sites tracked by the U.S. federal government's Digital Analytics Program."
       }
     },
     {
@@ -69,7 +85,7 @@
       },
       "meta": {
         "names": "Operating Systems",
-        "description": "Weekly visits, broken down by operating system and date, for all .gov sites tracked by the U.S. federal government's Digital Analytics Program."
+        "description": "90 days of visits, broken down by operating system and date, for all .gov sites tracked by the U.S. federal government's Digital Analytics Program."
       }
     },
     {
@@ -86,7 +102,7 @@
       },
       "meta": {
         "names": "Windows",
-        "description": "Weekly visits from Windows users, broken down by operating system version and date, for all .gov sites tracked by the U.S. federal government's Digital Analytics Program."
+        "description": "90 days of visits from Windows users, broken down by operating system version and date, for all .gov sites tracked by the U.S. federal government's Digital Analytics Program."
       }
     },
     {
@@ -103,7 +119,7 @@
       },
       "meta": {
         "name": "Browsers",
-        "description": "Weekly visits broken down by browser for all .gov sites tracked by the U.S. federal government's Digital Analytics Program."
+        "description": "90 days of visits broken down by browser for all .gov sites tracked by the U.S. federal government's Digital Analytics Program."
       }
     },
     {
@@ -120,7 +136,7 @@
       },
       "meta": {
         "name": "Internet Explorer",
-        "description": "Weekly visits from Internet Explorer users broken down by version for all .gov sites tracked by the U.S. federal government's Digital Analytics Program."
+        "description": "90 days of visits from Internet Explorer users broken down by version for all .gov sites tracked by the U.S. federal government's Digital Analytics Program."
       }
     },
     {
@@ -133,8 +149,8 @@
         "max-results": "20"
       },
       "meta": {
-        "name": "Top Pages (7 Days)",
-        "description": "Last week's top 20 pages in terms of sessions for all .gov sites tracked by the U.S. federal government's Digital Analytics Program."
+        "name": "Top Pages (Live)",
+        "description": "The top 20 pages, measured by active onsite users, for all .gov sites tracked by the U.S. federal government's Digital Analytics Program."
       }
     },
     {
@@ -150,7 +166,7 @@
       },
       "meta": {
         "name": "Top Pages (7 Days)",
-        "description": "Last week's top 20 pages in terms of sessions for all .gov sites tracked by the U.S. federal government's Digital Analytics Program."
+        "description": "Last week's top 20 pages, measured by visits, for all .gov sites tracked by the U.S. federal government's Digital Analytics Program."
       }
     },
     {
@@ -166,7 +182,7 @@
       },
       "meta": {
         "name": "Top Pages (30 Days)",
-        "description": "Last 30 day's top 20 pages in terms of sessions for all .gov sites tracked by the U.S. federal government's Digital Analytics Program."
+        "description": "Last 30 days' top 20 pages, measured by visits, for all .gov sites tracked by the U.S. federal government's Digital Analytics Program."
       }
     },
     {
@@ -182,7 +198,7 @@
       },
       "meta": {
         "name": "Top Pages (90 Days)",
-        "description": "Last 90 day's top 20 pages in terms of sessions for all .gov sites tracked by the U.S. federal government's Digital Analytics Program."
+        "description": "Last 90 days' top 20 pages, measured by visits, for all .gov sites tracked by the U.S. federal government's Digital Analytics Program."
       }
     }
   ]


### PR DESCRIPTION
This gives the `1.05 billion` number shown in https://github.com/GSA/public_analytics/pull/33. 

However, from an efficiency/engineering perspective, this could also be calculated by summing the 3 `devices` totals -- they come out to exactly the same number.