### PR TITLE
gzip files before publishing to S3

### DIFF
--- a/bin/analytics
+++ b/bin/analytics
@@ -21,8 +21,9 @@ var Analytics = require("../analytics"),
     config = require("../config"),
     fs = require("fs"),
     path = require('path'),
-    async = require("async")
-    csv = require("fast-csv");
+    async = require("async"),
+    csv = require("fast-csv"),
+    zlib = require('zlib');
 
 
 // AWS credentials are looked for in env vars or in ~/.aws/config.
@@ -35,13 +36,18 @@ var publish = function(name, data, extension, options, callback) {
 
   var mime = {".json": "application/json", ".csv": "text/csv"};
 
-  new AWS.S3({params: {Bucket: config.aws.bucket}}).upload({
-    Key: config.aws.path + "/" + name + extension,
-    Body: data,
-    ContentType: mime[extension],
-    ACL: "public-read",
-    CacheControl: "max-age=" + (config.aws.cache || 0)
-  }, callback);
+  zlib.gzip(data, function(err, compressed) {
+    if (err) return console.log("ERROR AFTER GZIP: " + err);
+
+    new AWS.S3({params: {Bucket: config.aws.bucket}}).upload({
+      Key: config.aws.path + "/" + name + extension,
+      Body: compressed,
+      ContentType: mime[extension],
+      ContentEncoding: "gzip",
+      ACL: "public-read",
+      CacheControl: "max-age=" + (config.aws.cache || 0)
+    }, callback);
+  });
 };
 
 

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "analytics-reporter",
-  "version": "0.3.0",
+  "version": "0.4.0",
   "description": "A lightweight command line tool for reporting and publishing analytics data from a Google Analytics account.",
   "keywords": ["analytics", "google analytics"],
   "homepage": "https://github.com/18f/analytics-reporter",


### PR DESCRIPTION
This saves lots of bandwidth, and is standard stuff. It uses Node's [native gzip support](http://nodejs.org/api/zlib.html#zlib_zlib_gzip_buf_callback), and requires no changes to anyone using the data in a web browser. 

It may affect people using third party tools, but again, gzip is standard stuff. People using `curl` will need to add the `--compress` flag to automatically decompress the JSON. I'm not sure how to handle it with `wget`.