### PR TITLE
Moves the `today` report to be on a "realtime" schedule

### DIFF
--- a/analytics.js
+++ b/analytics.js
@@ -63,7 +63,7 @@ var Analytics = {
         query.auth = jwt;
 
         var api_call;
-        if (report.frequency == "realtime")
+        if (report.realtime)
             api_call = ga.data.realtime.get;
         else
             api_call = ga.data.ga.get;

--- a/deploy/crontab
+++ b/deploy/crontab
@@ -9,15 +9,6 @@
 # source $HOME/.bashrc
 # $HOME/node_modules/analytics-reporter/bin/analytics --publish --frequency=daily --slim --verbose
 
-################################
-# Contents of hourly.sh:
-
-# #!/bin/bash
-#
-# export PATH=$PATH:/usr/local/bin
-# source $HOME/.bashrc
-# $HOME/node_modules/analytics-reporter/bin/analytics --publish --frequency=hourly --slim --verbose
-
 #############################
 # Contents of realtime.sh:
 
@@ -29,9 +20,6 @@
 
 # most reports
 10 5 * * * /home/analytics/daily.sh > /home/analytics/logs/daily.log 2>&1
-
-# a couple hourly reports
-1 * * * * /home/analytics/hourly.sh > /home/analytics/logs/hourly.log 2>&1
 
 # realtime reports
 */1 * * * * /home/analytics/realtime.sh > /home/analytics/logs/realtime.log 2>&1

--- a/reports.json
+++ b/reports.json
@@ -3,6 +3,7 @@
     {
       "name": "realtime",
       "frequency": "realtime",
+      "realtime": true,
       "query": {
         "metrics": ["rt:activeUsers"]
       },
@@ -13,7 +14,7 @@
     },
     {
       "name": "today",
-      "frequency": "hourly",
+      "frequency": "realtime",
       "query": {
         "dimensions": ["ga:date", "ga:hour"],
         "metrics": ["ga:sessions"],
@@ -23,20 +24,6 @@
       "meta": {
         "name": "Today",
         "description": "Today's visits for all .gov sites tracked by the U.S. federal government's Digital Analytics Program."
-      }
-    },
-    {
-      "name": "yesterday",
-      "frequency": "hourly",
-      "query": {
-        "dimensions": ["ga:date", "ga:hour"],
-        "metrics": ["ga:sessions"],
-        "start-date": "yesterday",
-        "end-date": "yesterday"
-      },
-      "meta": {
-        "name": "Yesterday",
-        "description": "Yesterday's visits for all .gov sites tracked by the U.S. federal government's Digital Analytics Program."
       }
     },
     {
@@ -142,6 +129,7 @@
     {
       "name": "top-pages-realtime",
       "frequency": "realtime",
+      "realtime": true,
       "query": {
         "dimensions": ["rt:pagePath", "rt:pageTitle"],
         "metrics": ["rt:activeUsers"],


### PR DESCRIPTION
More accurately, a minute-ly schedule. We may end up needing to detach that further down the line if we have the reports from the Realtime API go below a minute in granularity.