### PR TITLE
Update nodejs server; fix bugs; remove mongo; add reports

### DIFF
--- a/README.md
+++ b/README.md
@@ -33,6 +33,16 @@ export ANALYTICS_KEY_PATH="/path/to/secret_key.pem"
 ```
 You may wish to manage these using [`autoenv`](https://github.com/kennethreitz/autoenv).
 
+To find your Google Analytics view ID:
+
+  1. Sign in to your Analytics account.
+  1. Select the Admin tab.
+  1. Select an account from the dropdown in the ACCOUNT column.
+  1. Select a property from the dropdown in the PROPERTY column.
+  1. Select a view from the dropdown in the VIEW column.
+  1. Click "View Settings"
+  1. Copy the view ID.  You'll need to enter it with `ga:` as a prefix.
+
 * Test your configuration by printing a report to STDOUT:
 
 ```bash
@@ -84,7 +94,7 @@ A report might look something like this:
   },
   "meta": {
     "name": "Devices",
-    "description": "Weekly desktop/mobile/tablet visits by day for all .gov sites tracked by the U.S. federal government's Digital Analytics Program."
+    "description": "Weekly desktop/mobile/tablet visits by day for all sites."
   },
   "data": [
     {

--- a/analytics.js
+++ b/analytics.js
@@ -107,7 +107,10 @@ var Analytics = {
         "ga:hostname": "domain",
         "ga:browser" : 'browser',
         "ga:browserVersion" : "browser_version",
-        "ga:source": "source"
+        "ga:source": "source",
+        "ga:pagePath": "page",
+        "ga:pageTitle": "page_title",
+        "ga:pageviews": "visits"
     },
 
     // The OSes we care about for the OS breakdown. The rest can be "Other".

--- a/analytics.js
+++ b/analytics.js
@@ -168,6 +168,9 @@ var Analytics = {
 
                 point[field] = value;
             }
+            if (report.realtime && config.account.hostname) {
+              point.domain = config.account.hostname;
+            }
 
             result.data.push(point);
         }

--- a/analytics.js
+++ b/analytics.js
@@ -9,10 +9,14 @@ var googleapis = require('googleapis'),
 
 var config = require('./config');
 
+// Pre-load the keyfile from the OS
+// prevents errors when starting JWT
+var key = fs.readFileSync(config.key);
+
 var jwt = new googleapis.auth.JWT(
     config.email,
-    config.key,
     null,
+    key,
     ['https://www.googleapis.com/auth/analytics.readonly']
 );
 

--- a/app/app.js
+++ b/app/app.js
@@ -1,21 +1,17 @@
-// Connect to the database.
-var mongo = require("../config").mongo;
-require('mongoose').connect('mongodb://' + mongo.host + '/' + mongo.database);
-
 // Define the app, and middleware.
 var express = require('express'),
     app = express();
 app.use(require('body-parser').json());
 app.set('port', process.env.PORT || 3000);
 
-
 // Attach the routes.
 var models = require("./models");
-app.get('/', function (req, res) {
-    res.send("Hello, world!");
-});
 require('./routes')(app, models);
 
+// Static files
+var config = require('../config');
+console.log(config.static.path);
+app.use(express.static(config.static.path));
 
 //init model
 var async = require("async"),
@@ -26,14 +22,15 @@ time_mapper = {'daily': 86400000, 'hourly': 3600000, 'realtime': 10000}
 
 var eachReport = function(name, callback) {
     var report = Analytics.reports[name];
-        var doc = new models.Analytics({
-            name: name,
-            update_interval: time_mapper[report.frequency],
-            last_update: 0,
-            query: report.query
-        });
-    doc.save();
+    var doc = {
+        name: name,
+        update_interval: time_mapper[report.frequency],
+        last_update: 0,
+        query: report.query,
+        realtime: report.realtime
+    };
     console.log("Created endpoint: " + doc.name);
+    models.data[name] = doc;
     callback();
 };
 

--- a/app/data_update.js
+++ b/app/data_update.js
@@ -1,7 +1,7 @@
 var models = require('./models'),
     Analytics = require("../analytics"),
     config = require("../config"),
-    fs = require("fs")
+    fs = require("fs");
 
 module.exports = {
     get_or_update: function(err, res, doc) {
@@ -11,22 +11,25 @@ module.exports = {
             if (current_time - doc.update_interval > doc.last_update) {
                 console.log("updated @ " + doc.last_update);
                 Analytics.query(doc, function(err, data) {
+                    // if the data returned isn't valid, abort and return null
+                    if (data == null) {
+                      return res.json(null);
+                    }
+                    // store the data returned in cache
                     doc.data = {'data': data['data'],
                                 'totals': data['totals']};
                     doc.last_update = current_time;
-                    doc.save();
+                    models.data[doc.name] = doc;
                     res.json(doc.data);
                 });
             }
             // Update if it's time
             else {
-                console.log('not updated')
                 res.json(doc.data);
             }
         }
         // If it doesn't exist
         else{
-            console.log("couldn't find anything");
             res.status(404).json("The endpoint you attempted to reach does not exist, try a different API call.");
         }
 

--- a/app/models.js
+++ b/app/models.js
@@ -1,31 +1,6 @@
-var mongoose = require('mongoose');
-var Mixed = mongoose.Schema.Types.Mixed;
+// Connect to the database.
+var db = {};
 
 module.exports = {
-    Analytics: mongoose.model(
-        'AnalyticsSchema', new mongoose.Schema({
-            name: {
-                type: String,
-                required: true,
-                unique: true
-            },
-             query: {
-                type: Mixed,
-                required: true,
-                unique: true
-            },
-            update_interval: {
-                type: Number,
-                required: false
-            },
-            last_update: {
-                type: Number,
-                required: false
-            },
-            data: {
-                type: Mixed,
-                required: false
-            }
-        })
-    )
+    data: db
 };

--- a/app/routes.js
+++ b/app/routes.js
@@ -1,20 +1,25 @@
 // All routes for the app.
 var models = require('./models'),
-    config = require('../config'),
-    data = require('./data_update');
+    data = require('./data_update'),
+    path = require('path');
+
+String.prototype.endsWith = function (s) {
+  return this.length >= s.length && this.substr(this.length - s.length) == s;
+}
 
 module.exports = function(app, models) {
 
-    app.get('/data/api/', function(req, res) {
+    app.get('/data/live/', function(req, res) {
         res.send("API Data!");
     });
 
-    app.get('/data/api/:name', function(req, res) {
-        models.Analytics.findOne({
-            name: req.params.name
-        }, function(err, doc) {
-            data.get_or_update(err, res, doc);
-        });
+    app.get('/data/live/:name', function(req, res) {
+      var name = req.params.name;
+      if (name.endsWith(".json")) {
+        name = name.substring(0, name.length-5);
+      }
+      var doc = models.data[name];
+      data.get_or_update(null, res, doc);
     });
 
 };

--- a/config.js
+++ b/config.js
@@ -25,10 +25,8 @@ module.exports = {
     ids: process.env.ANALYTICS_REPORT_IDS
   },
 
-  mongo: {
-    host: process.env.MONGO_HOST,
-    database: process.env.MONGO_DATABASE
+  static: {
+    path: '../analytics.usa.gov/'
   }
-
 
 };

--- a/config.js
+++ b/config.js
@@ -22,7 +22,10 @@ module.exports = {
   },
 
   account: {
-    ids: process.env.ANALYTICS_REPORT_IDS
+    ids: process.env.ANALYTICS_REPORT_IDS,
+    // needed for realtime reports which don't include hostname
+    // leave blank if your view includes hostnames
+    hostname: process.env.ANALYTICS_HOSTNAME || ""
   },
 
   static: {

--- a/package.json
+++ b/package.json
@@ -49,7 +49,6 @@
   },
   "devDependencies": {
     "body-parser": "~1.8.1",
-    "express": "~4.9.0",
-    "mongoose": "^3.8.19"
+    "express": "~4.9.0"
   }
 }

--- a/reports.json
+++ b/reports.json
@@ -9,7 +9,7 @@
       },
       "meta": {
         "name": "Active Users Right Now",
-        "description": "Number of users currently visiting all sites tracked by the U.S. federal government's Digital Analytics Program."
+        "description": "Number of users currently visiting all sites."
       }
     },
     {
@@ -18,12 +18,12 @@
       "query": {
         "dimensions": ["ga:date", "ga:hour"],
         "metrics": ["ga:sessions"],
-        "start-date": "today",
+        "start-date": "yesterday",
         "end-date": "today"
       },
       "meta": {
         "name": "Today",
-        "description": "Today's visits for all .gov sites tracked by the U.S. federal government's Digital Analytics Program."
+        "description": "Today's visits for all sites."
       }
     },
     {
@@ -39,7 +39,7 @@
       },
       "meta": {
         "name": "Visitors",
-        "description": "90 days of visits for all .gov sites tracked by the U.S. federal government's Digital Analytics Program."
+        "description": "90 days of visits for all sites."
       }
     },
     {
@@ -55,7 +55,7 @@
       },
       "meta": {
         "name": "Devices",
-        "description": "90 days of desktop/mobile/tablet visits for all .gov sites tracked by the U.S. federal government's Digital Analytics Program."
+        "description": "90 days of desktop/mobile/tablet visits for all sites."
       }
     },
     {
@@ -72,7 +72,7 @@
       },
       "meta": {
         "names": "Operating Systems",
-        "description": "90 days of visits, broken down by operating system and date, for all .gov sites tracked by the U.S. federal government's Digital Analytics Program."
+        "description": "90 days of visits, broken down by operating system and date, for all sites."
       }
     },
     {
@@ -89,7 +89,7 @@
       },
       "meta": {
         "names": "Windows",
-        "description": "90 days of visits from Windows users, broken down by operating system version and date, for all .gov sites tracked by the U.S. federal government's Digital Analytics Program."
+        "description": "90 days of visits from Windows users, broken down by operating system version and date, for all sites."
       }
     },
     {
@@ -106,7 +106,7 @@
       },
       "meta": {
         "name": "Browsers",
-        "description": "90 days of visits broken down by browser for all .gov sites tracked by the U.S. federal government's Digital Analytics Program."
+        "description": "90 days of visits broken down by browser for all sites."
       }
     },
     {
@@ -123,7 +123,7 @@
       },
       "meta": {
         "name": "Internet Explorer",
-        "description": "90 days of visits from Internet Explorer users broken down by version for all .gov sites tracked by the U.S. federal government's Digital Analytics Program."
+        "description": "90 days of visits from Internet Explorer users broken down by version for all sites."
       }
     },
     {
@@ -138,7 +138,39 @@
       },
       "meta": {
         "name": "Top Pages (Live)",
-        "description": "The top 20 pages, measured by active onsite users, for all .gov sites tracked by the U.S. federal government's Digital Analytics Program."
+        "description": "The top 20 pages, measured by active onsite users, for all sites."
+      }
+    },
+    {
+      "name": "top-pages-7-days",
+      "frequency": "daily",
+      "query": {
+        "dimensions": ["ga:pagePath", "ga:pageTitle"],
+        "metrics": ["ga:pageviews"],
+        "start-date": "7daysAgo",
+        "end-date": "yesterday",
+        "sort": "-ga:pageviews",
+        "max-results": "20"
+      },
+      "meta": {
+        "name": "Top Pages (7 Days)",
+        "description": "Last week's top 20 pages, measured by page views, for all sites."
+      }
+    },
+    {
+      "name": "top-pages-30-days",
+      "frequency": "daily",
+      "query": {
+        "dimensions": ["ga:pagePath", "ga:pageTitle"],
+        "metrics": ["ga:pageviews"],
+        "start-date": "30daysAgo",
+        "end-date": "yesterday",
+        "sort": "-ga:pageviews",
+        "max-results": "20"
+      },
+      "meta": {
+        "name": "Top Pages (30 Days)",
+        "description": "Last 30 days' top 20 pages, measured by page views, for all sites."
       }
     },
     {
@@ -154,7 +186,7 @@
       },
       "meta": {
         "name": "Top Domains (7 Days)",
-        "description": "Last week's top 20 domains, measured by visits, for all .gov sites tracked by the U.S. federal government's Digital Analytics Program."
+        "description": "Last week's top 20 domains, measured by visits, for all sites."
       }
     },
     {
@@ -170,7 +202,7 @@
       },
       "meta": {
         "name": "Top Domains (30 Days)",
-        "description": "Last 30 days' top 20 domains, measured by visits, for all .gov sites tracked by the U.S. federal government's Digital Analytics Program."
+        "description": "Last 30 days' top 20 domains, measured by visits, for all sites."
       }
     }
   ]

--- a/reports.json
+++ b/reports.json
@@ -18,6 +18,20 @@
       "query": {
         "dimensions": ["ga:date", "ga:hour"],
         "metrics": ["ga:sessions"],
+        "start-date": "today",
+        "end-date": "today"
+      },
+      "meta": {
+        "name": "Today",
+        "description": "Today's visits for all sites."
+      }
+    },
+    {
+      "name": "last-48-hours",
+      "frequency": "realtime",
+      "query": {
+        "dimensions": ["ga:date", "ga:hour"],
+        "metrics": ["ga:sessions"],
         "start-date": "yesterday",
         "end-date": "today"
       },
@@ -145,7 +159,7 @@
       "name": "top-pages-7-days",
       "frequency": "daily",
       "query": {
-        "dimensions": ["ga:pagePath", "ga:pageTitle"],
+        "dimensions": ["ga:hostname", "ga:pagePath", "ga:pageTitle"],
         "metrics": ["ga:pageviews"],
         "start-date": "7daysAgo",
         "end-date": "yesterday",
@@ -161,7 +175,7 @@
       "name": "top-pages-30-days",
       "frequency": "daily",
       "query": {
-        "dimensions": ["ga:pagePath", "ga:pageTitle"],
+        "dimensions": ["ga:hostname", "ga:pagePath", "ga:pageTitle"],
         "metrics": ["ga:pageviews"],
         "start-date": "30daysAgo",
         "end-date": "yesterday",


### PR DESCRIPTION
Add instructions for finding Google Analytics view ID

Preload the server application key.
See http://stackoverflow.com/questions/23554526/nodejs-jwt-sign-sign-typeerror-not-a-buffer

The nodejs app wasn't passing the realtime flag to the
Analytics main library which was causing failures.
Add in passing that flag.

MongoDB was complete overkill.  For a handful of reports,
they fit very comfortably in a small amount of RAM (lets say
around a megabyte).  Just use an array in memory and wipe
out the complexity of mongo. Remove dependency on mongo
from package.json.

The routes for the API data didn't match the frontend code.
Update the routes to /data/live/ instead of /data/api/

Add a config option to serve static content. Since a
separate repo has the HTML/CSS/JS files, allow express
to serve those statically from the node app.  By just
configuring the config.static.path variable, express
will do the rest.

If you're not running multiple domains (which I'm going to assume
is most organizations), the 7/30 day page views report is more
useful than the 7/30 day domains report.

The descriptions all says ".gov" and "digital analytics program"
for every report.  No need to be that specific, especially if
we want others to use the analytics-reporter.  Remove this
identifying information.

Add new 48 hour ga report 

Add optional hostname config