### PR TITLE
WIP: Allow key to be passed in as raw text

### DIFF
--- a/analytics.js
+++ b/analytics.js
@@ -12,10 +12,11 @@ var config = require('./config');
 // Pre-load the keyfile from the OS
 // prevents errors when starting JWT
 var key;
-if (fs.existsSync(config.key))
-    key = fs.readFileSync(config.key);
-else
-    key = null;
+    if (config.key)
+    key = config.key;
+    else if (config.key_file && fs.existsSync(config.key_file))
+    key = fs.readFileSync(config.key_file);
+    else key = null;
 
 var jwt = new googleapis.auth.JWT(
     config.email,

--- a/config.js
+++ b/config.js
@@ -3,7 +3,8 @@
 module.exports = {
 
   email: process.env.ANALYTICS_REPORT_EMAIL,
-  key: process.env.ANALYTICS_KEY_PATH,
+  key: process.env.ANALYTICS_KEY,
+  key_file: process.env.ANALYTICS_KEY_PATH,
 
   debug: (process.env.ANALYTICS_DEBUG ? true : false),
 


### PR DESCRIPTION
This WIP PR by @laurenancona allows the app to function in a Heroku or Heroku-like environment, instead of requiring a path to a key file on disk.

Opening the PR in part to solicit feedback before it's done, and in part so I can convince GitHub to make a little box with git command instructions for checking out someone's remote branch.