### PR TITLE
Multi report run through --only option to save API queries

### DIFF
--- a/README.md
+++ b/README.md
@@ -170,6 +170,7 @@ analytics --publish
 
 ```bash
 analytics --only devices
+analytics --only "devices,today"
 ```
 
 * `--slim` -Where supported, use totals only (omit the `data` array). Only applies to JSON, and reports where `"slim": true`.

--- a/README.md
+++ b/README.md
@@ -166,7 +166,7 @@ analytics --output /path/to/data
 analytics --publish
 ```
 
-* `--only` - only run one report.
+* `--only` - only run one or more specific reports. Multiple reports comma separated, encapsulated by quotes.
 
 ```bash
 analytics --only devices

--- a/bin/analytics
+++ b/bin/analytics
@@ -58,8 +58,9 @@ var run = function(options) {
 
   // can be overridden to only do one report
   var names;
-  if (options.only)
-    names = [options.only];
+  if (options.only){
+    names = options.only.split(",");
+  }
   else if (options.frequency) {
     names = [];
     var all = Object.keys(Analytics.reports);


### PR DESCRIPTION
Rather than allowing only to support just one report name, allow one or more reports to be run on the same API call.
I found running multiple types of reports at identical schedules to bog down the 50,000 API limit and this helps reduce overall queries.