### PR TITLE
Example .env file at example.env

### DIFF
--- a/README.md
+++ b/README.md
@@ -8,11 +8,13 @@ Available reports are named and described in [`reports.json`](reports.json). For
 
 ### Setup
 
-* Install through npm:
+* To run the utility on your computer, install it through npm:
 
 ```bash
 npm install -g analytics-reporter
 ```
+
+If you're developing locally inside the repo, `npm install` is sufficient.
 
 * [Create an API service account](https://developers.google.com/accounts/docs/OAuth2ServiceAccount) in the Google developer dashboard.
 
@@ -35,7 +37,7 @@ export ANALYTICS_REPORT_EMAIL="YYYYYYY@developer.gserviceaccount.com"
 export ANALYTICS_REPORT_IDS="ga:XXXXXX"
 ```
 
-You may wish to manage these using [`autoenv`](https://github.com/kennethreitz/autoenv).
+You may wish to manage these using [`autoenv`](https://github.com/kennethreitz/autoenv). If you do, there is an `example.env` file you can copy to `.env` to get started.
 
 To find your Google Analytics view ID:
 

--- a/README.md
+++ b/README.md
@@ -31,7 +31,7 @@ openssl pkcs12 -in <name of your p12 key>.p12 -out secret_key.pem -nocerts -node
 * Set environment variables for your app's generated email address, and for the profile you authorized it to:
 
 ```bash
-export ANALYTICS_REPORT_EMAIL="asdfghjkl@developer.gserviceaccount.com"
+export ANALYTICS_REPORT_EMAIL="YYYYYYY@developer.gserviceaccount.com"
 export ANALYTICS_REPORT_IDS="ga:XXXXXX"
 ```
 

--- a/env.example
+++ b/env.example
@@ -1,0 +1,11 @@
+export ANALYTICS_REPORT_EMAIL="YYYYYYY@developer.gserviceaccount.com"
+export ANALYTICS_REPORT_IDS="ga:XXXXXX"
+export ANALYTICS_KEY_PATH="/path/to/secret_key.pem"
+
+export AWS_REGION=us-east-1
+export AWS_ACCESS_KEY_ID=[your-key]
+export AWS_SECRET_ACCESS_KEY=[your-secret-key]
+
+export AWS_BUCKET=[your-bucket]
+export AWS_BUCKET_PATH=[your-path]
+export AWS_CACHE_TIME=0


### PR DESCRIPTION
Standard-ish convention for indicating a template for a `.env` file, and more clearly documents what environment variables are expected.