### PR TITLE
Make default report JSON not use 1000-visit threshold filters

### DIFF
--- a/reports/usa.json
+++ b/reports/usa.json
@@ -81,6 +81,7 @@
         "metrics": ["ga:sessions"],
         "start-date": "90daysAgo",
         "end-date": "yesterday",
+        "filters": ["ga:sessions>1000"],
         "sort": "ga:date"
       },
       "meta": {
@@ -97,7 +98,7 @@
         "metrics": ["ga:sessions"],
         "start-date": "90daysAgo",
         "end-date": "yesterday",
-        "filters": ["ga:operatingSystem==Windows"],
+        "filters": ["ga:operatingSystem==Windows;ga:sessions>1000"],
         "sort": "ga:date"
       },
       "meta": {
@@ -114,7 +115,8 @@
         "metrics": ["ga:sessions"],
         "start-date": "90daysAgo",
         "end-date": "yesterday",
-        "sort": "ga:date,-ga:sessions"
+        "sort": "ga:date,-ga:sessions",
+        "filters": ["ga:sessions>1000"]
       },
       "meta": {
         "name": "Browsers",
@@ -131,7 +133,7 @@
         "start-date": "90daysAgo",
         "end-date": "yesterday",
         "sort": "ga:date,-ga:sessions",
-        "filters": ["ga:browser==Internet Explorer"]
+        "filters": ["ga:browser==Internet Explorer;ga:sessions>1000"]
       },
       "meta": {
         "name": "Internet Explorer",


### PR DESCRIPTION
This makes the default `reports/reports.json` drop the 1000-visit thresholds for reporting browser/OS information.

Since the federal government needs this threshold to effectively query its database for a complete report of information, a new `reports/usa.json` is added to the repository. This is what the analytics.usa.gov team will use going forward.

cc @polastre