### PR TITLE
Add a report and functionality to export participating second-level domains

### DIFF
--- a/analytics.js
+++ b/analytics.js
@@ -189,6 +189,10 @@ var Analytics = {
                 var point = {};
                 for (var j=0; j<row.length; j++) {
 
+                    // Some reports may decide to cut fields from the output.
+                    if (report.cut && _.contains(report.cut, data.columnHeaders[j].name))
+                        continue;
+
                     var field = Analytics.mapping[data.columnHeaders[j].name] || data.columnHeaders[j].name;
                     var value = row[j];
 

--- a/analytics.js
+++ b/analytics.js
@@ -66,10 +66,10 @@ var Analytics = {
         // Optional filters.
         var filters = [];
         if (report.query.filters)
-            filters.concat(report.query.filters);
+            filters = filters.concat(report.query.filters);
 
         if (report.filters)
-            filters.concat(report.filters);
+            filters = filters.concat(report.filters);
 
         if (filters.length > 0)
             query.filters = filters.join(";");

--- a/analytics.js
+++ b/analytics.js
@@ -42,6 +42,9 @@ var Analytics = {
 
     query: function(report, callback) {
 
+        // Abort if the report isn't defined.
+        if (!report) return callback();
+
         // Insert IDs and auth data. Dupe the object so it doesn't
         // modify the report object for later work.
         var query = {};

--- a/analytics.js
+++ b/analytics.js
@@ -66,13 +66,13 @@ var Analytics = {
         // Optional filters.
         var filters = [];
         if (report.query.filters)
-            filters.push(report.query.filters);
+            filters.concat(report.query.filters);
 
         if (report.filters)
-            filters.push(report.filters);
+            filters.concat(report.filters);
 
         if (filters.length > 0)
-            query.filters = filters.join(",");
+            query.filters = filters.join(";");
 
         query['max-results'] = report.query['max-results'] || 10000;
 

--- a/bin/analytics
+++ b/bin/analytics
@@ -80,7 +80,7 @@ var run = function(options) {
 
     if (options.debug) console.log("\n[" + report.name + "] Fetching...");
     Analytics.query(report, function(err, data) {
-        if (err) return console.log("ERROR AFTER QUERYING: " + JSON.stringify(err));
+        if (err) return console.log("ERROR AFTER QUERYING: " + err);
 
         if (options.debug) console.log("[" + report.name + "] Saving report data...");
 

--- a/bin/analytics
+++ b/bin/analytics
@@ -76,6 +76,8 @@ var run = function(options) {
   var eachReport = function(name, done) {
     var report = Analytics.reports[name];
 
+    if (!report) return done('Report not defined.');
+
     if (options.debug) console.log("\n[" + report.name + "] Fetching...");
     Analytics.query(report, function(err, data) {
         if (err) return console.log("ERROR AFTER QUERYING: " + JSON.stringify(err));
@@ -117,7 +119,7 @@ var run = function(options) {
       fs.writeFile(path.join(options.output, (name + extension)), output, written);
 
     else {
-      // could be split on \n\n
+      // allows users to pretty reliably split on \n\n
       console.log(output + "\n");
       written();
     }

--- a/reports/usa.json
+++ b/reports/usa.json
@@ -98,7 +98,10 @@
         "metrics": ["ga:sessions"],
         "start-date": "90daysAgo",
         "end-date": "yesterday",
-        "filters": ["ga:operatingSystem==Windows;ga:sessions>1000"],
+        "filters": [
+          "ga:operatingSystem==Windows",
+          "ga:sessions>1000"
+        ],
         "sort": "ga:date"
       },
       "meta": {
@@ -133,7 +136,10 @@
         "start-date": "90daysAgo",
         "end-date": "yesterday",
         "sort": "ga:date,-ga:sessions",
-        "filters": ["ga:browser==Internet Explorer;ga:sessions>1000"]
+        "filters": [
+          "ga:browser==Internet Explorer",
+          "ga:sessions>1000"
+        ]
       },
       "meta": {
         "name": "Internet Explorer",
@@ -226,7 +232,9 @@
       "query": {
         "dimensions": ["ga:hostname"],
         "metrics": ["ga:sessions"],
-        "filters": ["ga:hostname=~^[^\\.]+\\.[^\\.]+$"],
+        "filters": [
+          "ga:hostname=~^[^\\.]+\\.[^\\.]+$"
+        ],
         "start-date": "14daysAgo",
         "end-date": "yesterday",
         "sort": "ga:hostname",

--- a/reports/usa.json
+++ b/reports/usa.json
@@ -233,6 +233,7 @@
         "dimensions": ["ga:hostname"],
         "metrics": ["ga:sessions"],
         "filters": [
+          "ga:sessions>4",
           "ga:hostname=~^[^\\.]+\\.[^\\.]+$"
         ],
         "start-date": "14daysAgo",

--- a/reports/usa.json
+++ b/reports/usa.json
@@ -218,6 +218,24 @@
         "name": "Top Domains (30 Days)",
         "description": "Last 30 days' top 20 domains, measured by visits, for all sites."
       }
+    },
+    {
+      "name": "second-level-domains",
+      "frequency": "daily",
+      "cut": ["ga:sessions"],
+      "query": {
+        "dimensions": ["ga:hostname"],
+        "metrics": ["ga:sessions"],
+        "filters": ["ga:hostname=~^[^\\.]+\\.[^\\.]+$"],
+        "start-date": "14daysAgo",
+        "end-date": "yesterday",
+        "sort": "ga:hostname",
+        "max-results": 10000
+      },
+      "meta": {
+        "name": "Participating second-level domains.",
+        "description": "Participating second-level domains over the last 2 weeks."
+      }
     }
   ]
 }


### PR DESCRIPTION
This touches general functionality a bit, and adds a report to export domains:

* Handles missing reports (or mistaken report names) more gracefully, displaying an error and exiting with a `1` response code instead of getting a stack trace.
* Allows reports to specify a `cut` field, with an array of (original Google Analytics) field names that should be cut from the output report.
* A new report in the `usa.json` reports file that exports participating second-level domains from the previous 2 weeks. A regex is used to limit the participating hostnames to those with one dot (`.`) in them. This report uses `cut` to exclude the number of sessions, as the report is only about publishing participation. Google Analytics requires a `dimension` in order to execute queries, necessitating this.