### PR TITLE
Bump to version 0.5.0

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "analytics-reporter",
-  "version": "0.4.3",
+  "version": "0.5.0",
   "description": "A lightweight command line tool for reporting and publishing analytics data from a Google Analytics account.",
   "keywords": ["analytics", "google analytics"],
   "homepage": "https://github.com/18f/analytics-reporter",


### PR DESCRIPTION
It's been ~6 months since the last time we updated `npm`. This bumps the version number to `0.5.0` and marks another push to `npm`.