### PR TITLE
Add a CSV export for daily reports to crontab

### DIFF
--- a/deploy/crontab
+++ b/deploy/crontab
@@ -8,6 +8,7 @@
 # export PATH=$PATH:/usr/local/bin
 # source $HOME/.bashrc
 # $HOME/node_modules/analytics-reporter/bin/analytics --publish --frequency=daily --slim --verbose
+# $HOME/node_modules/analytics-reporter/bin/analytics --publish --frequency=daily --slim --verbose --csv
 
 #############################
 # Contents of realtime.sh:


### PR DESCRIPTION
This is an analytics.usa.gov-specific concern, but we're now using the `--csv` flag to publish CSV versions of daily reports (not realtime reports).