### PR TITLE
Add Microsoft Edge and Windows 10 to the whitelist

### DIFF
--- a/analytics.js
+++ b/analytics.js
@@ -150,13 +150,13 @@ var Analytics = {
     // The versions of Windows we care about for the Windows version breakdown.
     // The rest can be "Other". These are the exact strings used by Google Analytics.
     windows_versions: [
-        "XP", "Vista", "7", "8", "8.1"
+        "XP", "Vista", "7", "8", "8.1", "10"
     ],
 
     // The browsers we care about for the browser report. The rest are "Other"
     //  These are the exact strings used by Google Analytics.
     browsers: [
-        "Internet Explorer", "Chrome", "Safari", "Firefox", "Android Browser",
+        "Internet Explorer", "Edge", "Chrome", "Safari", "Firefox", "Android Browser",
         "Safari (in-app)", "Amazon Silk", "Opera", "Opera Mini",
         "IE with Chrome Frame", "BlackBerry", "UC Browser"
     ],


### PR DESCRIPTION
We currently whitelist which browser and OS names (as well as Windows and IE versions) to aggregate into the totals field for the 90-day reports. This adds support for a browser and an OS that Microsoft released since we released the dashboard in March.

* Edge is a new browser, not a version of Internet Explorer. We could make an editorial decision to treat it as a new version of IE, but it'd require some refactoring, and maybe we should wait until it's an issue. It doesn't automatically show up on the dashboard, because its % is below the threshold to avoid being lumped into "Other".

* Windows 10 is a new version of Windows. It automatically shows up in the version list, and has substantial use:

![image](https://cloud.githubusercontent.com/assets/4592/10579732/dafb582c-7647-11e5-9b8c-0ffa52be175a.png)
