### PR TITLE
Bulk data reports for real-time pages, 30-day domains

### DIFF
--- a/analytics.js
+++ b/analytics.js
@@ -195,7 +195,7 @@ var Analytics = {
 
             // get indices of column headers, for reference in client-side thresholds
             var columnIndices = {};
-            for (var c=0; c<data.columnHeaders.length; c++)
+            for (var c = 0; c < data.columnHeaders.length; c++)
                 columnIndices[data.columnHeaders[c].name] = c;
 
             // Calculate each individual data point.

--- a/analytics.js
+++ b/analytics.js
@@ -193,9 +193,21 @@ var Analytics = {
         // data.rows is missing if there are no results
         if (data.totalResults > 0) {
 
+            // get indices of column headers, for reference in client-side thresholds
+            var columnIndices = {};
+            for (var c=0; c<data.columnHeaders.length; c++)
+                columnIndices[data.columnHeaders[c].name] = c;
+
             // Calculate each individual data point.
             for (var i=0; i<data.rows.length; i++) {
                 var row = data.rows[i];
+
+                // allow client-side imposition of a value threshold, where it can't
+                // be done at the server-side (e.g. metric filters on RT reports)
+                if (report.threshold) {
+                    if (parseInt(row[columnIndices[report.threshold.field]]) < report.threshold.value)
+                        continue;
+                }
 
                 var point = {};
                 for (var j=0; j<row.length; j++) {
@@ -221,12 +233,12 @@ var Analytics = {
 
             // Go through those data points to calculate totals.
             // Right now, this is totally report-specific.
-            if ("visitors" in result.data[0]) {
+            if ((result.data.length > 0) && ("visitors" in result.data[0])) {
                 result.totals.visitors = 0;
                 for (var i=0; i<result.data.length; i++)
                     result.totals.visitors += parseInt(result.data[i].visitors);
             }
-            if ("visits" in result.data[0]) {
+            if ((result.data.length > 0) && ("visits" in result.data[0])) {
                 result.totals.visits = 0;
                 for (var i=0; i<result.data.length; i++)
                     result.totals.visits += parseInt(result.data[i].visits);
@@ -310,7 +322,7 @@ var Analytics = {
             }
             
             // presumably we're organizing these by date
-            if (result.data[0].date) {
+            if ((result.data.length > 0) && (result.data[0].date)) {
                 result.totals.start_date = result.data[0].date;
                 result.totals.end_date = result.data[result.data.length-1].date;
             }

--- a/reports/usa.json
+++ b/reports/usa.json
@@ -450,23 +450,7 @@
         "description": "Pages, measured by active onsite users, for all sites."
       }
     },
-    {
-      "name": "all-pages-30-days",
-      "frequency": "daily",
-      "query": {
-        "dimensions": ["ga:hostname", "ga:pagePath", "ga:pageTitle"],
-        "metrics": ["ga:pageviews"],
-        "start-date": "30daysAgo",
-        "end-date": "yesterday",
-        "sort": "-ga:pageviews",
-        "max-results": "10000",
-        "filters": ["ga:pageviews>=1000"]
-      },
-      "meta": {
-        "name": "All Pages (30 Days)",
-        "description": "Last 30 days' pages, measured by page views, for all sites."
-      }
-    },
+
     {
       "name": "all-domains-30-days",
       "frequency": "daily",

--- a/reports/usa.json
+++ b/reports/usa.json
@@ -430,6 +430,59 @@
         "name": "Non-US countries in the last 90 days.",
         "description": "90 days of visits from non-US countries broken down by country for all sites."
       }
-    } 
+    },
+    {
+      "name": "all-pages-realtime",
+      "frequency": "realtime",
+      "realtime": true,
+      "threshold": {
+        "field": "rt:activeUsers",
+        "value": "10"
+      },
+      "query": {
+        "dimensions": ["rt:pagePath", "rt:pageTitle"],
+        "metrics": ["rt:activeUsers"],
+        "sort": "-rt:activeUsers",
+        "max-results": "10000"
+      },
+      "meta": {
+        "name": "All Pages (Live)",
+        "description": "Pages, measured by active onsite users, for all sites."
+      }
+    },
+    {
+      "name": "all-pages-30-days",
+      "frequency": "daily",
+      "query": {
+        "dimensions": ["ga:hostname", "ga:pagePath", "ga:pageTitle"],
+        "metrics": ["ga:pageviews"],
+        "start-date": "30daysAgo",
+        "end-date": "yesterday",
+        "sort": "-ga:pageviews",
+        "max-results": "10000",
+        "filters": ["ga:pageviews>=1000"]
+      },
+      "meta": {
+        "name": "All Pages (30 Days)",
+        "description": "Last 30 days' pages, measured by page views, for all sites."
+      }
+    },
+    {
+      "name": "all-domains-30-days",
+      "frequency": "daily",
+      "query": {
+        "dimensions": ["ga:hostname"],
+        "metrics": ["ga:sessions"],
+        "start-date": "30daysAgo",
+        "end-date": "yesterday",
+        "sort": "-ga:sessions",
+        "max-results": "10000",
+        "filters": ["ga:sessions>=1000"]
+      },
+      "meta": {
+        "name": "All Domains (30 Days)",
+        "description": "Last 30 days' domains, measured by visits, for all sites."
+      }
+    }
   ]
 }


### PR DESCRIPTION
This adds reports that extend the "Top 20" real-time pages and 30-day domains to go substantially further:

* All pages with at least 10 real-time visitors right now. (Right now: that's ~1,500 pages.)
* All domains with at least 1000 sessions in the last 30 days. (Right now: that's ~2,100 domains.)

I think the 1000 sessions limit for 30-days could be dropped lower, and I'm curious what others think.

I also experimented with a "All pages with at least X pageviews in the last 30 days." report, which is not present in this PR. That has very interesting data, but has the downside that it's now introducing a **third** unique measurement (pageviews -- we currently already use active visitors and sessions). If there's interest, I can include that.