### PR TITLE
Updating international-visits-90-days to avoid date break

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "analytics-reporter",
-  "version": "1.1.0",
+  "version": "1.1.1",
   "description": "A lightweight command line tool for reporting and publishing analytics data from a Google Analytics account.",
   "keywords": ["analytics", "google analytics"],
   "homepage": "https://github.com/18F/analytics-reporter",

--- a/reports/usa.json
+++ b/reports/usa.json
@@ -423,7 +423,7 @@
         "metrics": ["ga:sessions"],
         "start-date": "90daysAgo",
         "end-date": "yesterday",
-        "sort": "ga:date,-ga:sessions",
+        "sort": "-ga:sessions",
         "filters": ["ga:country!=United States"]
       },
       "meta": {


### PR DESCRIPTION
Looks like the report didn't have ga:date as a dimension. 