### PR TITLE
Streamline plus data

### DIFF
--- a/deploy/crontab
+++ b/deploy/crontab
@@ -2,5 +2,8 @@
 # most reports
 10 8 * * * /home/analytics/daily.sh > /home/analytics/logs/daily.log 2>&1
 
+# one 'today' report
+0 */1 * * * /home/analytics/hourly.sh > /home/analytics/logs/hourly.log 2>&1
+
 # realtime reports
 */1 * * * * /home/analytics/realtime.sh > /home/analytics/logs/realtime.log 2>&1

--- a/deploy/crontab
+++ b/deploy/crontab
@@ -1,23 +1,3 @@
-# Run all reports every day soon after midnight. Server uses UTC.
-
-################################
-# Contents of daily.sh:
-
-# #!/bin/bash
-#
-# export PATH=$PATH:/usr/local/bin
-# source $HOME/.bashrc
-# $HOME/node_modules/analytics-reporter/bin/analytics --publish --frequency=daily --slim --verbose
-# $HOME/node_modules/analytics-reporter/bin/analytics --publish --frequency=daily --slim --verbose --csv
-
-#############################
-# Contents of realtime.sh:
-
-# #!/bin/bash
-#
-# export PATH=$PATH:/usr/local/bin
-# source $HOME/.bashrc
-# $HOME/node_modules/analytics-reporter/bin/analytics --publish --frequency=realtime --slim --verbose
 
 # most reports
 10 5 * * * /home/analytics/daily.sh > /home/analytics/logs/daily.log 2>&1

--- a/deploy/crontab
+++ b/deploy/crontab
@@ -1,6 +1,6 @@
 
 # most reports
-10 5 * * * /home/analytics/daily.sh > /home/analytics/logs/daily.log 2>&1
+10 8 * * * /home/analytics/daily.sh > /home/analytics/logs/daily.log 2>&1
 
 # realtime reports
 */1 * * * * /home/analytics/realtime.sh > /home/analytics/logs/realtime.log 2>&1

--- a/deploy/daily.sh
+++ b/deploy/daily.sh
@@ -1,0 +1,8 @@
+#!/bin/bash
+
+export PATH=$PATH:/usr/local/bin
+source $HOME/.bashrc
+
+# JSON and CSV versions
+$HOME/node_modules/analytics-reporter/bin/analytics --publish --frequency=daily --slim --verbose
+$HOME/node_modules/analytics-reporter/bin/analytics --publish --frequency=daily --slim --verbose --csv

--- a/deploy/hourly.sh
+++ b/deploy/hourly.sh
@@ -1,0 +1,7 @@
+#!/bin/bash
+
+export PATH=$PATH:/usr/local/bin
+source $HOME/.bashrc
+
+# just the one awkward 'today' report
+$HOME/node_modules/analytics-reporter/bin/analytics --publish --frequency=hourly --slim --verbose

--- a/deploy/realtime.sh
+++ b/deploy/realtime.sh
@@ -1,0 +1,9 @@
+#!/bin/bash
+
+export PATH=$PATH:/usr/local/bin
+source $HOME/.bashrc
+
+$HOME/node_modules/analytics-reporter/bin/analytics --publish --frequency=realtime --slim --verbose
+
+# we want just one realtime report in CSV, hardcoded for now to save on API requests
+$HOME/node_modules/analytics-reporter/bin/analytics --publish --only=all-pages-realtime --slim --verbose

--- a/deploy/realtime.sh
+++ b/deploy/realtime.sh
@@ -6,4 +6,4 @@ source $HOME/.bashrc
 $HOME/node_modules/analytics-reporter/bin/analytics --publish --frequency=realtime --slim --verbose
 
 # we want just one realtime report in CSV, hardcoded for now to save on API requests
-$HOME/node_modules/analytics-reporter/bin/analytics --publish --only=all-pages-realtime --slim --verbose
+$HOME/node_modules/analytics-reporter/bin/analytics --publish --only=all-pages-realtime --slim --verbose --csv

--- a/env.example
+++ b/env.example
@@ -1,6 +1,6 @@
 export ANALYTICS_REPORT_EMAIL="YYYYYYY@developer.gserviceaccount.com"
 export ANALYTICS_REPORT_IDS="ga:XXXXXX"
-export ANALYTICS_KEY_PATH="/path/to/secret_key.pem"
+export ANALYTICS_KEY_PATH="/path/to/secret_key.json"
 
 # Optional: if your profile uses a single hostname, set it here.
 # It will be prepended to page paths.

--- a/env.example
+++ b/env.example
@@ -7,7 +7,7 @@ export ANALYTICS_KEY_PATH="/path/to/secret_key.json"
 # export ANALYTICS_HOSTNAME=https://example.gov
 
 # Optional: defaults to reports/reports.json inside module
-# export ANALYTICS_REPORTS_PATH=/path/to/report.json
+# export ANALYTICS_REPORTS_PATH=/path/to/reports/reports.json
 
 export AWS_REGION=us-east-1
 export AWS_ACCESS_KEY_ID=[your-key]

--- a/reports/usa.json
+++ b/reports/usa.json
@@ -14,7 +14,7 @@
     },
     {
       "name": "today",
-      "frequency": "realtime",
+      "frequency": "hourly",
       "query": {
         "dimensions": ["ga:date", "ga:hour"],
         "metrics": ["ga:sessions"],


### PR DESCRIPTION
This PR:
- breaks out the crontab scripts into their own files
- changes the daily refresh time from 5:10 UTC to 8:10 UTC, so that it's at the earliest 12:10 Pacific time and quota limits are refreshed
- changes the `today` report from "realtime" to "hourly", adds an `hourly.sh` script that runs it, and updates the crontab to run `hourly.sh` on an hourly basis
- adds an extra line to the `realtime.sh` script that asks for all-realtime-pages to be output in CSV every minute as well
