### PR TITLE
Updating top downloads report to exclude .swf files

### DIFF
--- a/reports/usa.json
+++ b/reports/usa.json
@@ -190,7 +190,7 @@
       "query": {
         "dimensions": ["ga:pageTitle", "ga:eventLabel", "ga:pagePath"],
         "metrics": ["ga:totalEvents"],
-        "filters": ["ga:eventCategory=~ownload"],
+        "filters": ["ga:eventCategory=~ownload", "ga:eventLabel!~swf$"],
         "start-date": "7daysAgo",
         "end-date": "yesterday",
         "sort": "-ga:totalEvents",


### PR DESCRIPTION
[Filter with Regex](https://developers.google.com/analytics/devguides/reporting/core/v3/reference#filters)