### PR TITLE
--output option with --publish

### DIFF
--- a/bin/analytics
+++ b/bin/analytics
@@ -40,7 +40,7 @@ var publish = function(name, data, extension, options, callback) {
     if (err) return console.log("ERROR AFTER GZIP: " + err);
 
     new AWS.S3({params: {Bucket: config.aws.bucket}}).upload({
-      Key: config.aws.path + "/" + name + extension,
+      Key: config.aws.path + "/" + options.output + name + extension,
       Body: compressed,
       ContentType: mime[extension],
       ContentEncoding: "gzip",
@@ -69,9 +69,13 @@ var run = function(options) {
         names.push(all[i]);
     }
   }
-
   else
     names = Object.keys(Analytics.reports);
+    
+  // Confirm that --output option is valid, 
+  // otherwise convert output to empty string
+  if (!options.output || (typeof(options.output) != "string")) 
+    options.output = '';
 
   var eachReport = function(name, done) {
     var report = Analytics.reports[name];
@@ -115,7 +119,7 @@ var run = function(options) {
     if (options.publish)
       publish(name, output, extension, options, written);
 
-    else if (options.output && (typeof(options.output) == "string"))
+    else if (options.output)
       fs.writeFile(path.join(options.output, (name + extension)), output, written);
 
     else {

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "analytics-reporter",
-  "version": "1.1.1",
+  "version": "1.1.2",
   "description": "A lightweight command line tool for reporting and publishing analytics data from a Google Analytics account.",
   "keywords": ["analytics", "google analytics"],
   "homepage": "https://github.com/18F/analytics-reporter",


### PR DESCRIPTION
Currently the `--output` option isn't used in the publish function so all reports are published to the root directory of the s3 bucket. This PR allows the users to publish reports to different locations in the s3 bucket. 