### PR TITLE
Mark our change on the server from 1 to 2 minutes per-realtime

### DIFF
--- a/deploy/crontab
+++ b/deploy/crontab
@@ -23,4 +23,4 @@
 10 5 * * * /home/analytics/daily.sh > /home/analytics/logs/daily.log 2>&1
 
 # realtime reports
-*/1 * * * * /home/analytics/realtime.sh > /home/analytics/logs/realtime.log 2>&1
+*/2 * * * * /home/analytics/realtime.sh > /home/analytics/logs/realtime.log 2>&1


### PR DESCRIPTION
As DAP expands analytics.usa.gov's reach to multiple profiles, this (for the time being) rate limits our "real time" reports down to every 2 minutes instead of every 1 minute. We're looking into bumping this back up.

This `crontab` file is analytics.usa.gov-specific, one of the few parts of this repo that's specific to that site. We're not automatically syncing this `crontab` file with our server's `crontab`, but I'm marking it here with a PR anyway so we have evidence of the change.