### PR TITLE
Add 30 days of downloads report

### DIFF
--- a/reports/usa.json
+++ b/reports/usa.json
@@ -219,6 +219,23 @@
       }
     },
     {
+      "name": "top-downloads-30-days",
+      "frequency": "daily",
+      "query": {
+        "dimensions": ["ga:pageTitle", "ga:eventLabel", "ga:pagePath"],
+        "metrics": ["ga:totalEvents"],
+        "filters": ["ga:eventCategory=~ownload", "ga:eventLabel!~swf$"],
+        "start-date": "30daysAgo",
+        "end-date": "yesterday",
+        "sort": "-ga:totalEvents",
+        "max-results": "100"
+      },
+      "meta": {
+        "name": "Top Downloads (30 Days)",
+        "description": "Top downloads in the last 30 days."
+      }
+    },      
+    {
       "name": "top-cities-realtime",
       "frequency": "realtime",
       "realtime": true,


### PR DESCRIPTION
7 days of downloads were still present in s3, just omitted from UI. Adds 30 days of downloads report.
Both will need to be surfaced in [analytics.usa.gov](https://github.com/18F/analytics.usa.gov/blob/18f-pages/_layouts/default.html#L367).

Closes #136. 