### PR TITLE
Version the real crontab, real production scripts

### DIFF
--- a/deploy/crontab
+++ b/deploy/crontab
@@ -1,26 +1,10 @@
 # Run all reports every day soon after midnight. Server uses UTC.
 
-################################
-# Contents of daily.sh:
+################################# most reports
+10 8 * * * /home/analytics/daily.sh > /home/analytics/logs/daily.log 2>&1
 
-# #!/bin/bash
-#
-# export PATH=$PATH:/usr/local/bin
-# source $HOME/.bashrc
-# $HOME/node_modules/analytics-reporter/bin/analytics --publish --frequency=daily --slim --verbose
-# $HOME/node_modules/analytics-reporter/bin/analytics --publish --frequency=daily --slim --verbose --csv
-
-#############################
-# Contents of realtime.sh:
-
-# #!/bin/bash
-#
-# export PATH=$PATH:/usr/local/bin
-# source $HOME/.bashrc
-# $HOME/node_modules/analytics-reporter/bin/analytics --publish --frequency=realtime --slim --verbose
-
-# most reports
-10 5 * * * /home/analytics/daily.sh > /home/analytics/logs/daily.log 2>&1
+# one 'today' report
+0 */1 * * * /home/analytics/hourly.sh > /home/analytics/logs/hourly.log 2>&1
 
 # realtime reports
 */2 * * * * /home/analytics/realtime.sh > /home/analytics/logs/realtime.log 2>&1

--- a/deploy/daily.sh
+++ b/deploy/daily.sh
@@ -1,0 +1,58 @@
+#!/bin/bash
+
+export PATH=$PATH:/usr/local/bin
+source $HOME/.bashrc
+
+# JSON and CSV versions
+$HOME/analytics-reporter/bin/analytics --publish --frequency=daily --slim --verbose
+$HOME/analytics-reporter/bin/analytics --publish --frequency=daily --slim --verbose --csv
+
+# ED Reports
+source $HOME/envs/ed.env
+$HOME/analytics-reporter/bin/analytics --publish --frequency=daily --slim --verbose
+$HOME/analytics-reporter/bin/analytics --publish --frequency=daily --slim --verbose --csv
+
+# VA Reports
+source $HOME/envs/va.env
+$HOME/analytics-reporter/bin/analytics --publish --frequency=daily --slim --verbose
+$HOME/analytics-reporter/bin/analytics --publish --frequency=daily --slim --verbose --csv
+
+# NASA Reports
+source $HOME/envs/nasa.env
+$HOME/analytics-reporter/bin/analytics --publish --frequency=daily --slim --verbose
+$HOME/analytics-reporter/bin/analytics --publish --frequency=daily --slim --verbose --csv
+
+# DOJ Reports
+source $HOME/envs/doj.env
+$HOME/analytics-reporter/bin/analytics --publish --frequency=daily --slim --verbose
+$HOME/analytics-reporter/bin/analytics --publish --frequency=daily --slim --verbose --csv
+
+# Commerce Reports
+source $HOME/envs/commerce.env
+$HOME/analytics-reporter/bin/analytics --publish --frequency=daily --slim --verbose
+$HOME/analytics-reporter/bin/analytics --publish --frequency=daily --slim --verbose --csv
+
+# EPA Reports
+source $HOME/envs/epa.env
+$HOME/analytics-reporter/bin/analytics --publish --frequency=daily --slim --verbose
+$HOME/analytics-reporter/bin/analytics --publish --frequency=daily --slim --verbose --csv
+
+# SBA Reports
+# source $HOME/envs/sba.env
+# $HOME/analytics-reporter/bin/analytics --publish --frequency=daily --slim --verbose
+# $HOME/analytics-reporter/bin/analytics --publish --frequency=daily --slim --verbose --csv
+
+# Energy Reports
+source $HOME/envs/energy.env
+$HOME/analytics-reporter/bin/analytics --publish --frequency=daily --slim --verbose
+$HOME/analytics-reporter/bin/analytics --publish --frequency=daily --slim --verbose --csv
+
+# DOI Reports
+source $HOME/envs/doi.env
+$HOME/analytics-reporter/bin/analytics --publish --frequency=daily --slim --verbose
+$HOME/analytics-reporter/bin/analytics --publish --frequency=daily --slim --verbose --csv
+
+# NARA Reports
+source $HOME/envs/nara.env
+$HOME/analytics-reporter/bin/analytics --publish --frequency=daily --slim --verbose
+$HOME/analytics-reporter/bin/analytics --publish --frequency=daily --slim --verbose --csv

--- a/deploy/hourly.sh
+++ b/deploy/hourly.sh
@@ -1,0 +1,47 @@
+#!/bin/bash
+
+export PATH=$PATH:/usr/local/bin
+source $HOME/.bashrc
+
+# just the one awkward 'today' report
+$HOME/analytics-reporter/bin/analytics --publish --frequency=hourly --slim --verbose
+
+# ED Reports
+source $HOME/envs/ed.env
+$HOME/analytics-reporter/bin/analytics --publish --frequency=hourly --slim --verbose
+
+# NASA Reports
+source $HOME/envs/nasa.env
+$HOME/analytics-reporter/bin/analytics --publish --frequency=hourly --slim --verbose
+
+# DOJ Reports
+source $HOME/envs/doj.env
+$HOME/analytics-reporter/bin/analytics --publish --frequency=hourly --slim --verbose
+
+# VA Reports
+source $HOME/envs/va.env
+$HOME/analytics-reporter/bin/analytics --publish --frequency=hourly --slim --verbose
+
+# Commerce Reports
+source $HOME/envs/commerce.env
+$HOME/analytics-reporter/bin/analytics --publish --frequency=hourly --slim --verbose
+
+# EPA Reports
+source $HOME/envs/epa.env
+$HOME/analytics-reporter/bin/analytics --publish --frequency=hourly --slim --verbose
+
+# SBA Reports
+source $HOME/envs/sba.env
+$HOME/analytics-reporter/bin/analytics --publish --frequency=hourly --slim --verbose
+
+# Energy Reports
+source $HOME/envs/energy.env
+$HOME/analytics-reporter/bin/analytics --publish --frequency=hourly --slim --verbose
+
+# DOI Reports
+source $HOME/envs/doi.env
+$HOME/analytics-reporter/bin/analytics --publish --frequency=hourly --slim --verbose
+
+# NARA Reports
+source $HOME/envs/nara.env
+$HOME/analytics-reporter/bin/analytics --publish --frequency=hourly --slim --verbose

--- a/deploy/realtime.sh
+++ b/deploy/realtime.sh
@@ -1,0 +1,62 @@
+#!/bin/bash
+
+export PATH=$PATH:/usr/local/bin
+source $HOME/.bashrc
+
+$HOME/analytics-reporter/bin/analytics --publish --frequency=realtime --slim --verbose
+
+# we want just one realtime report in CSV, hardcoded for now to save on API requests
+$HOME/analytics-reporter/bin/analytics --publish --only=all-pages-realtime --slim --verbose --csv
+
+# ED reports
+source $HOME/envs/ed.env
+$HOME/analytics-reporter/bin/analytics --publish --frequency=realtime --slim --verbose
+$HOME/analytics-reporter/bin/analytics --publish --only=all-pages-realtime --slim --verbose --csv
+
+# VA reports
+source $HOME/envs/va.env
+$HOME/analytics-reporter/bin/analytics --publish --frequency=realtime --slim --verbose
+$HOME/analytics-reporter/bin/analytics --publish --only=all-pages-realtime --slim --verbose --csv
+
+# NASA reports
+source $HOME/envs/nasa.env
+$HOME/analytics-reporter/bin/analytics --publish --frequency=realtime --slim --verbose
+$HOME/analytics-reporter/bin/analytics --publish --only=all-pages-realtime --slim --verbose --csv
+
+# DOJ reports
+source $HOME/envs/doj.env
+$HOME/analytics-reporter/bin/analytics --publish --frequency=realtime --slim --verbose
+$HOME/analytics-reporter/bin/analytics --publish --only=all-pages-realtime --slim --verbose --csv
+
+# Commerce reports
+source $HOME/envs/commerce.env
+$HOME/analytics-reporter/bin/analytics --publish --frequency=realtime --slim --verbose
+$HOME/analytics-reporter/bin/analytics --publish --only=all-pages-realtime --slim --verbose --csv
+
+# Use the second key from this point on
+source $HOME/credentials/dap_1.env
+
+# EPA reports
+source $HOME/envs/epa.env
+$HOME/analytics-reporter/bin/analytics --publish --frequency=realtime --slim --verbose
+$HOME/analytics-reporter/bin/analytics --publish --only=all-pages-realtime --slim --verbose --csv
+
+# sba reports
+# source $HOME/envs/sba.env
+# $HOME/analytics-reporter/bin/analytics --publish --frequency=realtime --slim --verbose
+# $HOME/analytics-reporter/bin/analytics --publish --only=all-pages-realtime --slim --verbose --csv
+
+# Energy reports
+source $HOME/envs/energy.env
+$HOME/analytics-reporter/bin/analytics --publish --frequency=realtime --slim --verbose
+$HOME/analytics-reporter/bin/analytics --publish --only=all-pages-realtime --slim --verbose --csv
+
+# DOI reports
+source $HOME/envs/doi.env
+$HOME/analytics-reporter/bin/analytics --publish --frequency=realtime --slim --verbose
+$HOME/analytics-reporter/bin/analytics --publish --only=all-pages-realtime --slim --verbose --csv
+
+# NARA reports
+source $HOME/envs/nara.env
+$HOME/analytics-reporter/bin/analytics --publish --frequency=realtime --slim --verbose
+$HOME/analytics-reporter/bin/analytics --publish --only=all-pages-realtime --slim --verbose --csv


### PR DESCRIPTION
This versions the crontab and scripts we use on our production server, so that we at least have them backed up and documented. This is 18F-specific, not part of the general analytics-reporter framework. We could potentially store these in the analytics.usa.gov/ repo, and maybe we should do that eventually.