### PR TITLE
Fixed device report. Left over dimensions removed.

### DIFF
--- a/reports/usa.json
+++ b/reports/usa.json
@@ -31,7 +31,7 @@
       "frequency": "daily",
       "slim": true,
       "query": {
-        "dimensions": ["ga:date" ,"ga:deviceCategory", "ga:language", "ga:screenResolution", "ga:mobileDeviceModel"],
+        "dimensions": ["ga:date" ,"ga:deviceCategory"],
         "metrics": ["ga:sessions"],
         "start-date": "90daysAgo",
         "end-date": "yesterday",


### PR DESCRIPTION
There were some extra dimensions left over in the usa.json reports file. I removed them from reports.json, but forgot to remove them from the usa.json. This push removes removes the extra dims.