### PR TITLE
For usa.json only: moving the 'today' report to hourly frequency

### DIFF
--- a/reports/usa.json
+++ b/reports/usa.json
@@ -14,7 +14,7 @@
     },
     {
       "name": "today",
-      "frequency": "realtime",
+      "frequency": "hourly",
       "query": {
         "dimensions": ["ga:date", "ga:hour"],
         "metrics": ["ga:sessions"],


### PR DESCRIPTION
This only affects users of `usa.json`, but it moves the `today` report (which drives the bar chart on analytic.shouse.gov of visits to websites every hour through the course of the day) to be an hourly report.

For us, we were often always falling an hour or more behind anyway due to the scale of the data. Hitting the non-realtime API for realtime data just wasn't producing great results. We had intended to move this to an hourly time limit earlier, and you can see in our deploy scripts (committed in #142) we have an [`hourly.sh` on our production server](https://github.com/18F/analytics-reporter/blob/master/deploy/hourly.sh) that intends to run the `today` report -- but it has not been running. This should fix that.