### PR TITLE
Bumped version to 1.1.2

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "analytics-reporter",
-  "version": "1.1.1",
+  "version": "1.1.2",
   "description": "A lightweight command line tool for reporting and publishing analytics data from a Google Analytics account.",
   "keywords": ["analytics", "google analytics"],
   "homepage": "https://github.com/18F/analytics-reporter",


### PR DESCRIPTION
I bumped the version and deployed to `npm` [on April 13th](https://github.com/18F/analytics-reporter/issues/151#issuecomment-209644709) in response to a bug, but neglected to commit the change to version control. This fixes that.