### PR TITLE
Report limit fix

### DIFF
--- a/analytics.js
+++ b/analytics.js
@@ -262,6 +262,29 @@ var Analytics = {
                     result.totals.visits += parseInt(result.data[i].visits);
             }
 
+            if (_.startsWith(report.name, "device_models")) {
+                result.totals.device_models = {};
+                for (var i=0; i<result.data.length; i++) {
+                    if(typeof result.totals.device_models[result.data[i].mobile_device] == "undefined") {
+                        result.totals.device_models[result.data[i].mobile_device] = result.data[i].visits;
+                    } else {
+                        result.totals.device_models[result.data[i].mobile_device] += parseInt(result.data[i].visits);
+                    }
+                }
+            }
+
+            if (_.startsWith(report.name, "language")) {
+                result.totals.languages = {};
+                for (var i=0; i<result.data.length; i++) {
+                    if(typeof result.totals.languages[result.data[i].language] == "undefined") {
+                        result.totals.languages[result.data[i].language] = result.data[i].visits;
+                    } else {
+                        result.totals.languages[result.data[i].language] += parseInt(result.data[i].visits);
+                    }
+                }
+            }
+
+
             if (_.startsWith(report.name, "devices")) {
                 result.totals.devices = {mobile: 0, desktop: 0, tablet: 0};
                 for (var i=0; i<result.data.length; i++)

--- a/analytics.js
+++ b/analytics.js
@@ -262,11 +262,11 @@ var Analytics = {
                     result.totals.visits += parseInt(result.data[i].visits);
             }
 
-            if (_.startsWith(report.name, "device_models")) {
+            if (_.startsWith(report.name, "device_model")) {
                 result.totals.device_models = {};
                 for (var i=0; i<result.data.length; i++) {
                     if(typeof result.totals.device_models[result.data[i].mobile_device] == "undefined") {
-                        result.totals.device_models[result.data[i].mobile_device] = result.data[i].visits;
+                        result.totals.device_models[result.data[i].mobile_device] = parseInt(result.data[i].visits);
                     } else {
                         result.totals.device_models[result.data[i].mobile_device] += parseInt(result.data[i].visits);
                     }
@@ -277,7 +277,7 @@ var Analytics = {
                 result.totals.languages = {};
                 for (var i=0; i<result.data.length; i++) {
                     if(typeof result.totals.languages[result.data[i].language] == "undefined") {
-                        result.totals.languages[result.data[i].language] = result.data[i].visits;
+                        result.totals.languages[result.data[i].language] = parseInt(result.data[i].visits);
                     } else {
                         result.totals.languages[result.data[i].language] += parseInt(result.data[i].visits);
                     }

--- a/reports/reports.json
+++ b/reports/reports.json
@@ -88,7 +88,7 @@
         "description": "90 days of visits, broken down by operating system and date, for all sites."
       }
     },
-        {
+    {
       "name": "screen-size",
       "frequency": "daily",
       "slim": true,
@@ -114,7 +114,7 @@
         "start-date": "90daysAgo",
         "end-date": "yesterday",
         "sort": "ga:date",
-        "filters": ["ga:sessions>1000"],
+        "filters": ["ga:sessions>1000"]
       },
       "meta": {
         "name": "Browser Language",
@@ -131,7 +131,7 @@
         "start-date": "90daysAgo",
         "end-date": "yesterday",
         "sort": "ga:date",
-        "filters": ["ga:sessions>1000"],
+        "filters": ["ga:sessions>1000"]
       },
       "meta": {
         "name": "Device Model",

--- a/reports/reports.json
+++ b/reports/reports.json
@@ -113,11 +113,12 @@
         "metrics": ["ga:sessions"],
         "start-date": "90daysAgo",
         "end-date": "yesterday",
-        "sort": "ga:date"
+        "sort": "ga:date",
+        "filters": ["ga:sessions>1000"],
       },
       "meta": {
         "name": "Browser Language",
-        "description": "90 days of visits by browser language for all sites."
+        "description": "90 days of visits by browser language for all sites. (>1000 sessions)"
       }
     },
     {
@@ -129,11 +130,12 @@
         "metrics": ["ga:sessions"],
         "start-date": "90daysAgo",
         "end-date": "yesterday",
-        "sort": "ga:date"
+        "sort": "ga:date",
+        "filters": ["ga:sessions>1000"],
       },
       "meta": {
         "name": "Device Model",
-        "description": "90 days of visits by Device Model for all sites."
+        "description": "90 days of visits by Device Model for all sites. (>1000 sessions)"
       }
     },
     {

--- a/reports/reports.json
+++ b/reports/reports.json
@@ -113,12 +113,11 @@
         "metrics": ["ga:sessions"],
         "start-date": "90daysAgo",
         "end-date": "yesterday",
-        "sort": "ga:date",
-        "filters": ["ga:sessions>1000"]
+        "sort": "ga:date"
       },
       "meta": {
         "name": "Browser Language",
-        "description": "90 days of visits by browser language for all sites. (>1000 sessions)"
+        "description": "90 days of visits by browser language for all sites."
       }
     },
     {
@@ -130,12 +129,11 @@
         "metrics": ["ga:sessions"],
         "start-date": "90daysAgo",
         "end-date": "yesterday",
-        "sort": "ga:date",
-        "filters": ["ga:sessions>1000"]
+        "sort": "ga:date"
       },
       "meta": {
         "name": "Device Model",
-        "description": "90 days of visits by Device Model for all sites. (>1000 sessions)"
+        "description": "90 days of visits by Device Model for all sites."
       }
     },
     {
@@ -224,16 +222,16 @@
       "frequency": "daily",
       "query": {
         "dimensions": [
-          "ga:hostname", 
-          "ga:pagePath", 
+          "ga:hostname",
+          "ga:pagePath",
           "ga:pageTitle"
         ],
         "metrics": [
-          "ga:pageviews", 
-          "ga:sessions", 
-          "ga:users", 
-          "ga:pageviewsPerSession", 
-          "ga:avgSessionDuration", 
+          "ga:pageviews",
+          "ga:sessions",
+          "ga:users",
+          "ga:pageviewsPerSession",
+          "ga:avgSessionDuration",
           "ga:exits"
         ],
         "start-date": "30daysAgo",

--- a/reports/usa.json
+++ b/reports/usa.json
@@ -69,11 +69,12 @@
         "metrics": ["ga:sessions"],
         "start-date": "90daysAgo",
         "end-date": "yesterday",
-        "sort": "ga:date"
+        "sort": "ga:date",
+        "filters": ["ga:sessions>1000"],
       },
       "meta": {
         "name": "Browser Language",
-        "description": "90 days of visits by browser language for all sites."
+        "description": "90 days of visits by browser language for all sites. (>1000 sessions)"
       }
     },
 
@@ -91,7 +92,7 @@
       },
       "meta": {
         "name": "Device Model",
-        "description": "90 days of visits by Device Model for all sites."
+        "description": "90 days of visits by Device Model for all sites. (>1000 sessions)"
       }
     },
 

--- a/reports/usa.json
+++ b/reports/usa.json
@@ -70,7 +70,7 @@
         "start-date": "90daysAgo",
         "end-date": "yesterday",
         "sort": "ga:date",
-        "filters": ["ga:sessions>1000"],
+        "filters": ["ga:sessions>1000"]
       },
       "meta": {
         "name": "Browser Language",
@@ -88,7 +88,8 @@
         "metrics": ["ga:sessions"],
         "start-date": "90daysAgo",
         "end-date": "yesterday",
-        "sort": "ga:date"
+        "sort": "ga:date",
+        "filters": ["ga:sessions>1000"]
       },
       "meta": {
         "name": "Device Model",


### PR DESCRIPTION
1. Limited device_model, and language reports to entries with >1000 sessions. 
2. Added code to aggregate these totals for these reports.

Addresses: https://github.com/18F/analytics.usa.gov/issues/364