### PR TITLE
Specify which version of the Google Analytics APIs we use

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,6 +1,6 @@
 ## Analytics Reporter
 
-A lightweight system for publishing analytics data from Google Analytics profiles.
+A lightweight system for publishing analytics data from Google Analytics profiles. Uses the [Google Analytics Core Reporting API v3](https://developers.google.com/analytics/devguides/reporting/core/v3/) and the [Google Analytics Real Time API v3](https://developers.google.com/analytics/devguides/reporting/realtime/v3/).
 
 Available reports are named and described in [`reports.json`](reports/reports.json). For now, they're hardcoded into the repository.
 


### PR DESCRIPTION
This updates the README to call out that we're on v3 of the Core Reporting and Realtime APIs.

Fixes #158. cc @thekaveman