### PR TITLE
Revamp and greatly expand browser and OS data publication

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -10,3 +10,4 @@
 /data
 todo.txt
 npm-debug.log
+*.swp

--- a/analytics.js
+++ b/analytics.js
@@ -386,6 +386,28 @@ var Analytics = {
                 }
             }
 
+            if (report.name == "windows-ie") {
+
+                // Two two-level hashes.
+                result.totals.by_windows = {};
+                result.totals.by_ie = {};
+
+                for (var i=0; i<result.data.length; i++) {
+                    var windows = result.data[i].os_version;
+                    var ie = result.data[i].browser_version;
+                    var visits = parseInt(result.data[i].visits)
+
+                    if (!result.totals.by_windows[windows]) result.totals.by_windows[windows] = {};
+                    if (!result.totals.by_windows[windows][ie]) result.totals.by_windows[windows][ie] = 0;
+
+                    if (!result.totals.by_ie[ie]) result.totals.by_ie[ie] = {};
+                    if (!result.totals.by_ie[ie][windows]) result.totals.by_ie[ie][windows] = 0;
+
+                    result.totals.by_windows[windows][ie] += visits;
+                    result.totals.by_ie[ie][windows] += visits;
+                }
+            }
+
             if (report.name == "windows-browsers") {
 
                 result.totals.by_windows = {};

--- a/analytics.js
+++ b/analytics.js
@@ -134,18 +134,18 @@ var Analytics = {
         "ga:city": 'city',
         "ga:eventLabel": "event_label",
         "ga:totalEvents": "total_events",
-        "ga:landingPagePath": "landing_page", 
-        "ga:exitPagePath": "exit_page", 
-        "ga:source": "source", 
-        "ga:hasSocialSourceReferral": "has_social_referral", 
+        "ga:landingPagePath": "landing_page",
+        "ga:exitPagePath": "exit_page",
+        "ga:source": "source",
+        "ga:hasSocialSourceReferral": "has_social_referral",
         "ga:referralPath": "referral_path",
-        "ga:pageviews": "pageviews", 
-        "ga:users": "users", 
-        "ga:pageviewsPerSession": "pageviews_per_session", 
-        "ga:avgSessionDuration": "avg_session_duration", 
+        "ga:pageviews": "pageviews",
+        "ga:users": "users",
+        "ga:pageviewsPerSession": "pageviews_per_session",
+        "ga:avgSessionDuration": "avg_session_duration",
         "ga:exits": "exits",
-        "ga:language": "language", 
-        "ga:screenResolution": "screen_resolution", 
+        "ga:language": "language",
+        "ga:screenResolution": "screen_resolution",
         "ga:mobileDeviceModel": "mobile_device",
         "rt:country": "country",
         "rt:city": "city",
@@ -156,7 +156,7 @@ var Analytics = {
     // The OSes we care about for the OS breakdown. The rest can be "Other".
     // These are the extract strings used by Google Analytics.
     oses: [
-        "Android", "BlackBerry",  "Windows Phone", "iOS",
+        "Android", "BlackBerry", "Windows Phone", "iOS",
         "Linux", "Macintosh", "Windows", "(not set)", "Chrome OS",
         "Nokia", "Samsung", "SymbianOS", "Xbox", "Firefox OS",
         "Nintendo Wii", "Playstation 3", "FreeBSD", "Playstation Vita",
@@ -291,7 +291,7 @@ var Analytics = {
                     result.totals.devices[result.data[i].device] += parseInt(result.data[i].visits);
             }
 
-            if (_.startsWith(report.name, "os")) {
+            if (report.name == "os") {
                 // initialize all cared-about OSes to 0
                 result.totals.os = {};
                 for (var i=0; i<Analytics.oses.length; i++)
@@ -309,7 +309,7 @@ var Analytics = {
                 }
             }
 
-            if (_.startsWith(report.name, "windows")) {
+            if (report.name == "windows") {
                 // initialize all cared-about versions to 0
                 result.totals.os_version = {};
                 for (var i=0; i<Analytics.windows_versions.length; i++)
@@ -327,7 +327,7 @@ var Analytics = {
                 }
             }
 
-            if (_.startsWith(report.name, "browsers")) {
+            if (report.name == "browsers") {
 
                 result.totals.browser = {};
                 for (var i=0; i<Analytics.browsers.length; i++)
@@ -344,7 +344,7 @@ var Analytics = {
                 }
             }
 
-            if (_.startsWith(report.name, "ie")) {
+            if (report.name == "ie") {
                 // initialize all cared-about versions to 0
                 result.totals.ie_version = {};
                 for (var i=0; i<Analytics.ie_versions.length; i++)
@@ -361,7 +361,52 @@ var Analytics = {
                     result.totals.ie_version[version] += parseInt(result.data[i].visits);
                 }
             }
-            
+
+            // For the combo reports, don't group by "Other", aim for completeness.
+
+            if (report.name == "os-browsers") {
+
+                // Two two-level hashes.
+                result.totals.by_os = {};
+                result.totals.by_browsers = {};
+
+                for (var i=0; i<result.data.length; i++) {
+                    var os = result.data[i].os;
+                    var browser = result.data[i].browser;
+                    var visits = parseInt(result.data[i].visits)
+
+                    if (!result.totals.by_os[os]) result.totals.by_os[os] = {};
+                    if (!result.totals.by_os[os][browser]) result.totals.by_os[os][browser] = 0;
+
+                    if (!result.totals.by_browsers[browser]) result.totals.by_browsers[browser] = {};
+                    if (!result.totals.by_browsers[browser][os]) result.totals.by_browsers[browser][os] = 0;
+
+                    result.totals.by_os[os][browser] += visits;
+                    result.totals.by_browsers[browser][os] += visits;
+                }
+            }
+
+            if (report.name == "windows-browsers") {
+
+                result.totals.by_windows = {};
+                result.totals.by_browsers = {};
+
+                for (var i=0; i<result.data.length; i++) {
+                    var version = result.data[i].os_version;
+                    var browser = result.data[i].browser;
+                    var visits = parseInt(result.data[i].visits)
+
+                    if (!result.totals.by_windows[version]) result.totals.by_windows[version] = {};
+                    if (!result.totals.by_windows[version][browser]) result.totals.by_windows[version][browser] = 0;
+
+                    if (!result.totals.by_browsers[browser]) result.totals.by_browsers[browser] = {};
+                    if (!result.totals.by_browsers[browser][version]) result.totals.by_browsers[browser][version] = 0;
+
+                    result.totals.by_windows[version][browser] += visits;
+                    result.totals.by_browsers[browser][version] += visits;
+                }
+            }
+
             // presumably we're organizing these by date
             if ((result.data.length > 0) && (result.data[0].date)) {
                 result.totals.start_date = result.data[0].date;

--- a/analytics.js
+++ b/analytics.js
@@ -153,39 +153,6 @@ var Analytics = {
         "rt:eventLabel": "event_label"
     },
 
-    // The OSes we care about for the OS breakdown. The rest can be "Other".
-    // These are the extract strings used by Google Analytics.
-    oses: [
-        "Android", "BlackBerry", "Windows Phone", "iOS",
-        "Linux", "Macintosh", "Windows", "(not set)", "Chrome OS",
-        "Nokia", "Samsung", "SymbianOS", "Xbox", "Firefox OS",
-        "Nintendo Wii", "Playstation 3", "FreeBSD", "Playstation Vita",
-        "Google TV", "SunOS", "LG", "Nintendo 3DS"
-    ],
-
-    // The versions of Windows we care about for the Windows version breakdown.
-    // The rest can be "Other". These are the exact strings used by Google Analytics.
-    windows_versions: [
-        "XP", "Vista", "7", "8", "8.1", "10"
-    ],
-
-    // The browsers we care about for the browser report. The rest are "Other"
-    //  These are the exact strings used by Google Analytics.
-    browsers: [
-        "Internet Explorer", "Edge", "Chrome", "Safari", "Firefox", "Android Browser",
-        "Safari (in-app)", "Amazon Silk", "Opera", "Opera Mini",
-        "IE with Chrome Frame", "BlackBerry", "UC Browser", "YaBrowser",
-        "Maxthon", "Coc Coc"
-    ],
-
-    // The versions of IE we care about for the IE version breakdown.
-    // "Edge" is considered a separate browser in Google Analytics, appears above.
-    // The rest can be "Other". These are the exact strings used by Google Analytics.
-    ie_versions: [
-        "11.0", "10.0", "9.0", "8.0", "7.0", "6.0"
-    ],
-
-
     // Given a report and a raw google response, transform it into our schema.
     process: function(report, data) {
         var result = {

--- a/analytics.js
+++ b/analytics.js
@@ -292,72 +292,49 @@ var Analytics = {
             }
 
             if (report.name == "os") {
-                // initialize all cared-about OSes to 0
                 result.totals.os = {};
-                for (var i=0; i<Analytics.oses.length; i++)
-                    result.totals.os[Analytics.oses[i]] = 0;
-                result.totals.os["Other"] = 0;
 
                 for (var i=0; i<result.data.length; i++) {
                     var os = result.data[i].os;
+                    var visits = parseInt(result.data[i].visits);
 
-                    // Bucket any we don't care about under "Other".
-                    if (Analytics.oses.indexOf(os) < 0)
-                        os = "Other";
-
-                    result.totals.os[os] += parseInt(result.data[i].visits);
+                    if (!result.totals.os[os]) result.totals.os[os] = 0;
+                    result.totals.os[os] += visits;
                 }
             }
 
             if (report.name == "windows") {
-                // initialize all cared-about versions to 0
                 result.totals.os_version = {};
-                for (var i=0; i<Analytics.windows_versions.length; i++)
-                    result.totals.os_version[Analytics.windows_versions[i]] = 0;
-                result.totals.os_version["Other"] = 0;
 
                 for (var i=0; i<result.data.length; i++) {
                     var version = result.data[i].os_version;
+                    var visits = parseInt(result.data[i].visits);
 
-                    // Bucket any we don't care about under "Other".
-                    if (Analytics.windows_versions.indexOf(version) < 0)
-                        version = "Other";
-
-                    result.totals.os_version[version] += parseInt(result.data[i].visits);
+                    if (!result.totals.os_version[version]) result.totals.os_version[version] = 0;
+                    result.totals.os_version[version] += visits;
                 }
             }
 
             if (report.name == "browsers") {
-
                 result.totals.browser = {};
-                for (var i=0; i<Analytics.browsers.length; i++)
-                    result.totals.browser[Analytics.browsers[i]] = 0;
-                result.totals.browser["Other"] = 0;
 
                 for (var i=0; i<result.data.length; i++) {
                     var browser = result.data[i].browser;
+                    var visits = parseInt(result.data[i].visits);
 
-                    if (Analytics.browsers.indexOf(browser) < 0)
-                        browser = "Other";
-
-                    result.totals.browser[browser] += parseInt(result.data[i].visits);
+                    if (!result.totals.browser[browser]) result.totals.browser[browser] = 0;
+                    result.totals.browser[browser] += visits;
                 }
             }
 
             if (report.name == "ie") {
-                // initialize all cared-about versions to 0
                 result.totals.ie_version = {};
-                for (var i=0; i<Analytics.ie_versions.length; i++)
-                    result.totals.ie_version[Analytics.ie_versions[i]] = 0;
-                result.totals.ie_version["Other"] = 0;
 
                 for (var i=0; i<result.data.length; i++) {
                     var version = result.data[i].browser_version;
+                    var visits = parseInt(result.data[i].visits);
 
-                    // Bucket any we don't care about under "Other".
-                    if (Analytics.ie_versions.indexOf(version) < 0)
-                        version = "Other";
-
+                    if (!result.totals.ie_version[version]) result.totals.ie_version[version] = 0;
                     result.totals.ie_version[version] += parseInt(result.data[i].visits);
                 }
             }

--- a/reports/reports.json
+++ b/reports/reports.json
@@ -187,7 +187,7 @@
       }
     },
     {
-      "name": "browser-os",
+      "name": "os-browsers",
       "frequency": "daily",
       "slim": true,
       "query": {
@@ -198,8 +198,47 @@
         "sort": "ga:date,-ga:sessions"
       },
       "meta": {
-        "name": "Browsers",
-        "description": "90 days of visits broken down by browser for all sites."
+        "name": "OS-browser combinations",
+        "description": "90 days of visits broken down by browser and OS for all sites."
+      }
+    },
+    {
+      "name": "windows-browsers",
+      "frequency": "daily",
+      "slim": true,
+      "query": {
+        "dimensions": ["ga:date" ,"ga:browser", "ga:operatingSystemVersion"],
+        "metrics": ["ga:sessions"],
+        "start-date": "90daysAgo",
+        "end-date": "yesterday",
+        "sort": "ga:date,-ga:sessions",
+        "filters": [
+          "ga:operatingSystem==Windows"
+        ]
+      },
+      "meta": {
+        "name": "Windows-browser combinations",
+        "description": "90 days of visits broken down by Windows versions and browser for all sites."
+      }
+    },
+    {
+      "name": "windows-ie",
+      "frequency": "daily",
+      "slim": true,
+      "query": {
+        "dimensions": ["ga:date","ga:browserVersion", "ga:operatingSystemVersion"],
+        "metrics": ["ga:sessions"],
+        "start-date": "90daysAgo",
+        "end-date": "yesterday",
+        "sort": "ga:date,-ga:sessions",
+        "filters": [
+          "ga:browser==Internet Explorer",
+          "ga:operatingSystem==Windows"
+        ]
+      },
+      "meta": {
+        "name": "IE on Windows",
+        "description": "90 days of visits from IE on Windows broken down by IE and Windows versions for all sites."
       }
     },
     {

--- a/reports/reports.json
+++ b/reports/reports.json
@@ -187,6 +187,22 @@
       }
     },
     {
+      "name": "browser-os",
+      "frequency": "daily",
+      "slim": true,
+      "query": {
+        "dimensions": ["ga:date" ,"ga:browser", "ga:operatingSystem"],
+        "metrics": ["ga:sessions"],
+        "start-date": "90daysAgo",
+        "end-date": "yesterday",
+        "sort": "ga:date,-ga:sessions"
+      },
+      "meta": {
+        "name": "Browsers",
+        "description": "90 days of visits broken down by browser for all sites."
+      }
+    },
+    {
       "name": "top-pages-realtime",
       "frequency": "realtime",
       "realtime": true,
@@ -222,16 +238,16 @@
       "frequency": "daily",
       "query": {
         "dimensions": [
-          "ga:hostname", 
-          "ga:pagePath", 
+          "ga:hostname",
+          "ga:pagePath",
           "ga:pageTitle"
         ],
         "metrics": [
-          "ga:pageviews", 
-          "ga:sessions", 
-          "ga:users", 
-          "ga:pageviewsPerSession", 
-          "ga:avgSessionDuration", 
+          "ga:pageviews",
+          "ga:sessions",
+          "ga:users",
+          "ga:pageviewsPerSession",
+          "ga:avgSessionDuration",
           "ga:exits"
         ],
         "start-date": "30daysAgo",

--- a/reports/usa.json
+++ b/reports/usa.json
@@ -170,6 +170,23 @@
       }
     },
     {
+      "name": "browser-os",
+      "frequency": "daily",
+      "slim": true,
+      "query": {
+        "dimensions": ["ga:date" ,"ga:browser", "ga:operatingSystem"],
+        "metrics": ["ga:sessions"],
+        "start-date": "90daysAgo",
+        "end-date": "yesterday",
+        "sort": "ga:date,-ga:sessions",
+        "filters": ["ga:sessions>1000"]
+      },
+      "meta": {
+        "name": "Browsers",
+        "description": "90 days of visits broken down by browser for all sites."
+      }
+    },
+    {
       "name": "top-pages-realtime",
       "frequency": "realtime",
       "realtime": true,
@@ -315,7 +332,7 @@
         "dimensions": ["ga:pageTitle", "ga:eventLabel", "ga:pagePath"],
         "metrics": ["ga:totalEvents"],
         "filters": [
-          "ga:eventCategory=~ownload", 
+          "ga:eventCategory=~ownload",
           "ga:eventLabel!~swf$",
           "ga:pagePath!~(usps.com).*\/(?i)(zip|doc).*"
         ],

--- a/reports/usa.json
+++ b/reports/usa.json
@@ -106,7 +106,7 @@
         "metrics": ["ga:sessions"],
         "start-date": "90daysAgo",
         "end-date": "yesterday",
-        "filters": ["ga:sessions>1000"],
+        "filters": ["ga:sessions>100"],
         "sort": "ga:date"
       },
       "meta": {
@@ -125,7 +125,7 @@
         "end-date": "yesterday",
         "filters": [
           "ga:operatingSystem==Windows",
-          "ga:sessions>1000"
+          "ga:sessions>100"
         ],
         "sort": "ga:date"
       },
@@ -144,7 +144,7 @@
         "start-date": "90daysAgo",
         "end-date": "yesterday",
         "sort": "ga:date,-ga:sessions",
-        "filters": ["ga:sessions>1000"]
+        "filters": ["ga:sessions>100"]
       },
       "meta": {
         "name": "Browsers",
@@ -163,7 +163,7 @@
         "sort": "ga:date,-ga:sessions",
         "filters": [
           "ga:browser==Internet Explorer",
-          "ga:sessions>1000"
+          "ga:sessions>100"
         ]
       },
       "meta": {
@@ -172,7 +172,7 @@
       }
     },
     {
-      "name": "browser-os",
+      "name": "os-browsers",
       "frequency": "daily",
       "slim": true,
       "query": {
@@ -181,11 +181,52 @@
         "start-date": "90daysAgo",
         "end-date": "yesterday",
         "sort": "ga:date,-ga:sessions",
-        "filters": ["ga:sessions>1000"]
+        "filters": ["ga:sessions>100"]
       },
       "meta": {
-        "name": "Browsers",
-        "description": "90 days of visits broken down by browser for all sites."
+        "name": "OS-browser combinations",
+        "description": "90 days of visits broken down by browser and OS for all sites."
+      }
+    },
+    {
+      "name": "windows-browsers",
+      "frequency": "daily",
+      "slim": true,
+      "query": {
+        "dimensions": ["ga:date" ,"ga:browser", "ga:operatingSystemVersion"],
+        "metrics": ["ga:sessions"],
+        "start-date": "90daysAgo",
+        "end-date": "yesterday",
+        "sort": "ga:date,-ga:sessions",
+        "filters": [
+          "ga:sessions>100",
+          "ga:operatingSystem==Windows"
+        ]
+      },
+      "meta": {
+        "name": "Windows-browser combinations",
+        "description": "90 days of visits broken down by Windows versions and browser for all sites."
+      }
+    },
+    {
+      "name": "windows-ie",
+      "frequency": "daily",
+      "slim": true,
+      "query": {
+        "dimensions": ["ga:date","ga:browserVersion", "ga:operatingSystemVersion"],
+        "metrics": ["ga:sessions"],
+        "start-date": "90daysAgo",
+        "end-date": "yesterday",
+        "sort": "ga:date,-ga:sessions",
+        "filters": [
+          "ga:sessions>100",
+          "ga:browser==Internet Explorer",
+          "ga:operatingSystem==Windows"
+        ]
+      },
+      "meta": {
+        "name": "IE on Windows",
+        "description": "90 days of visits from IE on Windows broken down by IE and Windows versions for all sites."
       }
     },
     {


### PR DESCRIPTION
This PR does a host of helpful things to OS and browser data reporting:

* Drops the threshold for normal `browser`, `os`, `windows`, and `ie` reports from 1000 visits to 100 visits, over 90 days. It still remains well below the 10K report row limit, and the data is interesting.
* Drops the `Other` bucket we were putting many OS/browser/Windows/IE values into, and instead lists every value that appears in the data. This does mean that some unusual values now appear (like `pa11y`, or `http:`), but they were already appearing in the CSV version, and they're legit user agents seeing use out there. They're interesting.
  * **Note:** The browser and OS graphs on the dashboard will be unaffected by this, they do their own `Other` bucketing at the display level. However, the Windows and IE graphs on the dashboard do not, and will need to add their own bucketing in a separate PR (forthcoming).
* Fixes a bug where we were reporting 0'd out some OS values (see [the live data as of now](https://analytics.usa.gov/data/live/os.json) for an example).
* Removes the manual whitelist of browsers, OSes, IE versions, and Windows versions. No need to keep those up to date anymore. As new things happen, they'll automatically show up in the bulk data. The analytics.usa.gov dashboard currently buckets to `Other` based on market share, so that can continue.

This also adds 3 new daily reports: `os-browsers`, `windows-browsers`, and `windows-ie`. These each do two-dimensional reports, where we ask for each unique combination of each dimension. 

* For example, `os-browsers` gives you the number of visits to `Chrome on Android` and `Edge on Windows`. 
* The `windows-browsers` report gives you numbers for `Firefox on Windows 7` and `Internet Explorer on Windows XP`.
* The `windows-ie` report gives you `IE8 on Windows 7` and `IE6 on Windows XP`. 
* (I experimented with an `os-ie` report, but it was not interesting.)

The CSV reports for these are similar to the single-dimension reports, where each row is one day's unique value. To provide useful aggregation, the JSON reports will give aggregate totals in two nested hashes, each of which makes one dimension and the other secondary.

For example, the `os-browsers` report adds a `by_os` hash to the `totals` section (edited data):

```json
"by_os": {
      "iOS": {
        "Safari": 427448540,
        "Safari (in-app)": 31388624,
        "Chrome": 18220851,
        "UC Browser": 85104
      },
      "Windows": {
        "Chrome": 513578168,
        "Internet Explorer": 395951540,
        "Firefox": 150145868,
        "Edge": 60245582,
        "Opera": 4378081
       }
}
```

And also adds a `by_browsers` hash right below it, with the same data flipped around:

```json
    "by_browsers": {
      "Safari": {
        "iOS": 427448540,
        "Macintosh": 101950374,
        "Windows Phone": 4037565,
        "Linux": 701462,
        "Windows": 352605,
        "Nokia": 40815
      },
      "Chrome": {
        "Windows": 513578168,
        "Android": 320973531,
        "Macintosh": 70237512,
        "iOS": 18220851,
        "Chrome OS": 19656146,
        "Linux": 5014548,
      }
}
```

So for folks using the aggregated totals for high level understanding of what's happening, they can see useful conclusions at a glance, without needing to slice and tally up the CSV themselves. The CSV is present so that anyone can dive into the details and re-slice them however it makes sense.

With 26 agencies and a main page, these 3 new daily reports (in JSON and CSV) will add ~160 API calls per day (27 * 3 * 2) for analytics.usa.gov, so very little impact.

I think this data will be very useful to the technology world -- I know I got a lot of utility just glancing through the data as I worked with it. It's definitely worth the API calls.

I'll follow up with a PR to analytics.usa.gov that adds links to the `/data` page, and adapts the IE and Windows version graphs to do their own `Other` bucketing.