### PR TITLE
Report for exporting all participating hostnames

### DIFF
--- a/reports/usa.json
+++ b/reports/usa.json
@@ -291,6 +291,26 @@
       }
     },
     {
+      "name": "sites",
+      "frequency": "daily",
+      "cut": ["ga:sessions"],
+      "query": {
+        "dimensions": ["ga:hostname"],
+        "metrics": ["ga:sessions"],
+        "filters": [
+          "ga:sessions>0"
+        ],
+        "start-date": "30daysAgo",
+        "end-date": "yesterday",
+        "sort": "ga:hostname",
+        "max-results": 10000
+      },
+      "meta": {
+        "name": "Participating hostnames.",
+        "description": "Participating hostnames over the last 30 days with at least 1 visit."
+      }
+    },
+    {
       "name": "top-downloads-yesterday",
       "frequency": "daily",
       "query": {
@@ -317,7 +337,7 @@
         "dimensions": ["ga:pageTitle", "ga:eventLabel", "ga:pagePath"],
         "metrics": ["ga:totalEvents"],
         "filters": [
-          "ga:eventCategory=~ownload", 
+          "ga:eventCategory=~ownload",
           "ga:eventLabel!~swf$",
           "ga:pagePath!~(usps.com).*\/(?i)(zip|doc).*"
         ],


### PR DESCRIPTION
This automates the publication of `sites.csv`, which is the set of participating websites in the DAP. The production of `second-level-domains.csv` is currently already automated, but this broadens it to include all hostnames. Like `second-level-domains`, the number of visits is cut out, leaving just the hostname.

The `second-level-domains` threshold is 5 visits over 14 days. This `sites` report currently in the PR is, as last discussed, 1 visit over 30 days.

Here's how thresholds look right now, for the `sites` report:

* 1 visit over 30 days produces a list of ~6200 domains.
* 1 visit over 14 days produces a list of ~5600 domains.
* 5 visits over 30 days produces a list of ~4900 domains.
* 5 visits over 14 days produces a list of ~4400 domains.

In all cases, there are lots of staging, test, and intranet domains. Going from 1 to 5 visits removes 1,000+ sites each time, but it's not always removing staging/test/intranet domains.

Note that this will move `sites.csv` from https://analytics.usa.gov/data/sites.csv to https://analytics.usa.gov/data/live/sites.csv. The dashboard page will need to be updated to point to the new URL (trivial).