### PR TITLE
Fix screen sizes report

### DIFF
--- a/analytics.js
+++ b/analytics.js
@@ -109,6 +109,10 @@ var Analytics = {
 
     // translate 20141228 -> 2014-12-28
     date_format: function(in_date) {
+        // This happens in screen-size for some reason.
+        // Return original string.
+        if (in_date == "(other)") return in_date;
+
         return [in_date.substr(0,4), in_date.substr(4, 2), in_date.substr(6, 2)].join("-")
     },
 
@@ -134,18 +138,18 @@ var Analytics = {
         "ga:city": 'city',
         "ga:eventLabel": "event_label",
         "ga:totalEvents": "total_events",
-        "ga:landingPagePath": "landing_page", 
-        "ga:exitPagePath": "exit_page", 
-        "ga:source": "source", 
-        "ga:hasSocialSourceReferral": "has_social_referral", 
+        "ga:landingPagePath": "landing_page",
+        "ga:exitPagePath": "exit_page",
+        "ga:source": "source",
+        "ga:hasSocialSourceReferral": "has_social_referral",
         "ga:referralPath": "referral_path",
-        "ga:pageviews": "pageviews", 
-        "ga:users": "users", 
-        "ga:pageviewsPerSession": "pageviews_per_session", 
-        "ga:avgSessionDuration": "avg_session_duration", 
+        "ga:pageviews": "pageviews",
+        "ga:users": "users",
+        "ga:pageviewsPerSession": "pageviews_per_session",
+        "ga:avgSessionDuration": "avg_session_duration",
         "ga:exits": "exits",
-        "ga:language": "language", 
-        "ga:screenResolution": "screen_resolution", 
+        "ga:language": "language",
+        "ga:screenResolution": "screen_resolution",
         "ga:mobileDeviceModel": "mobile_device",
         "rt:country": "country",
         "rt:city": "city",
@@ -361,10 +365,17 @@ var Analytics = {
                     result.totals.ie_version[version] += parseInt(result.data[i].visits);
                 }
             }
-            
+
             // presumably we're organizing these by date
             if ((result.data.length > 0) && (result.data[0].date)) {
-                result.totals.start_date = result.data[0].date;
+
+                // At least one report (screen-size) gives back a bogus
+                // first entry, for unknown reasons.
+                if (result.data[0].date == "(other)")
+                    result.totals.start_date = result.data[1].date;
+                else
+                    result.totals.start_date = result.data[0].date;
+
                 result.totals.end_date = result.data[result.data.length-1].date;
             }
         }

--- a/analytics.js
+++ b/analytics.js
@@ -295,6 +295,18 @@ var Analytics = {
                     result.totals.devices[result.data[i].device] += parseInt(result.data[i].visits);
             }
 
+            if (report.name == "screen-size") {
+                result.totals.screen_resolution = {};
+
+                for (var i=0; i<result.data.length; i++) {
+                    var screen_resolution = result.data[i].screen_resolution;
+                    var visits = parseInt(result.data[i].visits);
+
+                    if (!result.totals.screen_resolution[screen_resolution]) result.totals.screen_resolution[screen_resolution] = 0;
+                    result.totals.screen_resolution[screen_resolution] += visits;
+                }
+            }
+
             if (_.startsWith(report.name, "os")) {
                 // initialize all cared-about OSes to 0
                 result.totals.os = {};

--- a/reports/usa.json
+++ b/reports/usa.json
@@ -52,7 +52,8 @@
         "metrics": ["ga:sessions"],
         "start-date": "90daysAgo",
         "end-date": "yesterday",
-        "sort": "ga:date"
+        "sort": "ga:date",
+        "filters": ["ga:sessions>5000"]
       },
       "meta": {
         "name": "Screen Resolution",
@@ -317,7 +318,7 @@
         "dimensions": ["ga:pageTitle", "ga:eventLabel", "ga:pagePath"],
         "metrics": ["ga:totalEvents"],
         "filters": [
-          "ga:eventCategory=~ownload", 
+          "ga:eventCategory=~ownload",
           "ga:eventLabel!~swf$",
           "ga:pagePath!~(usps.com).*\/(?i)(zip|doc).*"
         ],


### PR DESCRIPTION
This resolves the issues I reported in #166:

* The `screen-size` report now uses a threshold of 5000 visits, to remove non-relevant resolutions and keep the report size within the 10K threshold (it's about ~5K).
* The report now aggregates resolutions like the other reports do, making the JSON version somewhat worthwhile (it's still not awesome, since it's hard to get an "at a glance" sense of the data from it).
* The `start_date` bug is fixed -- Google was sending down an inscrutable `(other)` value for the first response, with no date associated. The code now skips over that one if present, and assumes the 2nd row is the start date.

Fixes #166.