### PR TITLE
Limit sites.csv to 14-day window

### DIFF
--- a/reports/usa.json
+++ b/reports/usa.json
@@ -300,7 +300,7 @@
         "filters": [
           "ga:sessions>0"
         ],
-        "start-date": "30daysAgo",
+        "start-date": "14daysAgo",
         "end-date": "yesterday",
         "sort": "ga:hostname",
         "max-results": 10000


### PR DESCRIPTION
This is an addendum to #165 -- after internal discussion, we're harmonizing the `second-level-domains` and `sites` reports to both pull from 14-day windows instead of 30-day windows.