### PR TITLE
Fix issues with paths in cloud.gov

### DIFF
--- a/deploy/cron.js
+++ b/deploy/cron.js
@@ -1,14 +1,15 @@
 const exec = require("child_process").exec;
+const execSync = require("child_process").execSync;
 
 var daily_run = function(){
 	console.log("about to run daily.sh");
-	exec("./daily.sh > ../logs/daily.log 2>&1", (error,stdout,stderr) => {
+	exec("./deploy/daily.sh > ../logs/daily.log 2>&1", (error,stdout,stderr) => {
 		if (error){
 			console.error(`exec error: ${error}`);
 			return;
 		}
 		console.log("number of lines in daily.log:");
-		execSync("wc -l daily.log");
+		execSync("wc -l ../logs/daily.log");
 		console.log(`${stdout}`);
 		console.log(`stderr: ${stderr}`);
 	});
@@ -16,13 +17,13 @@ var daily_run = function(){
 
 var hourly_run = function(){
 	console.log("about to run hourly.sh");
-	exec("./hourly.sh > ../logs/hourly.log 2>&1", (error,stdout,stderr) => {
+	exec("./deploy/hourly.sh > ../logs/hourly.log 2>&1", (error,stdout,stderr) => {
 		if (error){
 			console.error(`exec error: ${error}`);
 			return;
 		}
 		console.log("number of lines in hourly.log:");
-		execSync("wc -l hourly.log");
+		execSync("wc -l ../logs/hourly.log");
 		console.log(`${stdout}`);
 		console.log(`stderr: ${stderr}`);
 	});
@@ -30,13 +31,13 @@ var hourly_run = function(){
 
 var realtime_run = function(){
 	console.log("realtime.sh is about to run");
-	exec("./realtime.sh > ../logs/realtime.log 2>&1", (error,stdout,stderr) => {
+	exec("./deploy/realtime.sh > ../logs/realtime.log 2>&1", (error,stdout,stderr) => {
 		if (error){
 			console.error(`exec error: ${error}`);
 			return;
 		}
 		console.log("number of lines in realtime.log:");
-		execSync("wc -l realtime.log");
+		execSync("wc -l ../logs/realtime.log");
 		console.log(`${stdout}`);
 		console.log(`stderr: ${stderr}`);
 	});

--- a/deploy/daily.sh
+++ b/deploy/daily.sh
@@ -1,168 +1,168 @@
 #!/bin/bash
 
 # JSON and CSV versions
-source $HOME/app/dap-1.env
-$HOME/app/bin/analytics --publish --frequency=daily --slim --verbose
-$HOME/app/bin/analytics --publish --frequency=daily --slim --verbose --csv
+source $HOME/dap-1.env
+$HOME/bin/analytics --publish --frequency=daily --slim --verbose
+$HOME/bin/analytics --publish --frequency=daily --slim --verbose --csv
 
 # ED Reports
-source $HOME/app/dap-1.env
-source $HOME/app/deploy/envs/ed.env
-$HOME/app/bin/analytics --publish --frequency=daily --slim --verbose
-$HOME/app/bin/analytics --publish --frequency=daily --slim --verbose --csv
+source $HOME/dap-1.env
+source $HOME/deploy/envs/ed.env
+$HOME/bin/analytics --publish --frequency=daily --slim --verbose
+$HOME/bin/analytics --publish --frequency=daily --slim --verbose --csv
 
 # VA Reports
-source $HOME/app/dap-1.env
-source $HOME/app/deploy/envs/va.env
-$HOME/app/bin/analytics --publish --frequency=daily --slim --verbose
-$HOME/app/bin/analytics --publish --frequency=daily --slim --verbose --csv
+source $HOME/dap-1.env
+source $HOME/deploy/envs/va.env
+$HOME/bin/analytics --publish --frequency=daily --slim --verbose
+$HOME/bin/analytics --publish --frequency=daily --slim --verbose --csv
 
 # NASA Reports
-source $HOME/app/dap-1.env
-source $HOME/app/deploy/envs/nasa.env
-$HOME/app/bin/analytics --publish --frequency=daily --slim --verbose
-$HOME/app/bin/analytics --publish --frequency=daily --slim --verbose --csv
+source $HOME/dap-1.env
+source $HOME/deploy/envs/nasa.env
+$HOME/bin/analytics --publish --frequency=daily --slim --verbose
+$HOME/bin/analytics --publish --frequency=daily --slim --verbose --csv
 
 # DOJ Reports
-source $HOME/app/dap-1.env
-source $HOME/app/deploy/envs/doj.env
-$HOME/app/bin/analytics --publish --frequency=daily --slim --verbose
-$HOME/app/bin/analytics --publish --frequency=daily --slim --verbose --csv
+source $HOME/dap-1.env
+source $HOME/deploy/envs/doj.env
+$HOME/bin/analytics --publish --frequency=daily --slim --verbose
+$HOME/bin/analytics --publish --frequency=daily --slim --verbose --csv
 
 # Commerce Reports
-source $HOME/app/dap-1.env
-source $HOME/app/deploy/envs/commerce.env
-$HOME/app/bin/analytics --publish --frequency=daily --slim --verbose
-$HOME/app/bin/analytics --publish --frequency=daily --slim --verbose --csv
+source $HOME/dap-1.env
+source $HOME/deploy/envs/commerce.env
+$HOME/bin/analytics --publish --frequency=daily --slim --verbose
+$HOME/bin/analytics --publish --frequency=daily --slim --verbose --csv
 
 # EPA Reports
-source $HOME/app/dap-1.env
-source $HOME/app/deploy/envs/epa.env
-$HOME/app/bin/analytics --publish --frequency=daily --slim --verbose
-$HOME/app/bin/analytics --publish --frequency=daily --slim --verbose --csv
+source $HOME/dap-1.env
+source $HOME/deploy/envs/epa.env
+$HOME/bin/analytics --publish --frequency=daily --slim --verbose
+$HOME/bin/analytics --publish --frequency=daily --slim --verbose --csv
 
 # SBA Reports
-source $HOME/app/dap-1.env
-source $HOME/app/deploy/envs/sba.env
-$HOME/app/bin/analytics --publish --frequency=daily --slim --verbose
-$HOME/app/bin/analytics --publish --frequency=daily --slim --verbose --csv
+source $HOME/dap-1.env
+source $HOME/deploy/envs/sba.env
+$HOME/bin/analytics --publish --frequency=daily --slim --verbose
+$HOME/bin/analytics --publish --frequency=daily --slim --verbose --csv
 
 # Energy Reports
-source $HOME/app/dap-1.env
-source $HOME/app/deploy/envs/energy.env
-$HOME/app/bin/analytics --publish --frequency=daily --slim --verbose
-$HOME/app/bin/analytics --publish --frequency=daily --slim --verbose --csv
+source $HOME/dap-1.env
+source $HOME/deploy/envs/energy.env
+$HOME/bin/analytics --publish --frequency=daily --slim --verbose
+$HOME/bin/analytics --publish --frequency=daily --slim --verbose --csv
 
 # DOI Reports
-source $HOME/app/dap-1.env
-source $HOME/app/deploy/envs/doi.env
-$HOME/app/bin/analytics --publish --frequency=daily --slim --verbose
-$HOME/app/bin/analytics --publish --frequency=daily --slim --verbose --csv
+source $HOME/dap-1.env
+source $HOME/deploy/envs/doi.env
+$HOME/bin/analytics --publish --frequency=daily --slim --verbose
+$HOME/bin/analytics --publish --frequency=daily --slim --verbose --csv
 
 # NARA Reports
-source $HOME/app/dap-1.env
-source $HOME/app/deploy/envs/nara.env
-$HOME/app/bin/analytics --publish --frequency=daily --slim --verbose
-$HOME/app/bin/analytics --publish --frequency=daily --slim --verbose --csv
+source $HOME/dap-1.env
+source $HOME/deploy/envs/nara.env
+$HOME/bin/analytics --publish --frequency=daily --slim --verbose
+$HOME/bin/analytics --publish --frequency=daily --slim --verbose --csv
 
 # Department of Agriculture
-source $HOME/app/dap-1.env
-source $HOME/app/deploy/envs/agriculture.env
-$HOME/app/bin/analytics --publish --frequency=daily --slim --verbose
-$HOME/app/bin/analytics --publish --frequency=daily --slim --verbose --csv
+source $HOME/dap-1.env
+source $HOME/deploy/envs/agriculture.env
+$HOME/bin/analytics --publish --frequency=daily --slim --verbose
+$HOME/bin/analytics --publish --frequency=daily --slim --verbose --csv
 
 # Department of Defense
-source $HOME/app/dap-1.env
-source $HOME/app/deploy/envs/defense.env
-$HOME/app/bin/analytics --publish --frequency=daily --slim --verbose
-$HOME/app/bin/analytics --publish --frequency=daily --slim --verbose --csv
+source $HOME/dap-1.env
+source $HOME/deploy/envs/defense.env
+$HOME/bin/analytics --publish --frequency=daily --slim --verbose
+$HOME/bin/analytics --publish --frequency=daily --slim --verbose --csv
 
 # Department of Health and Human Services
-source $HOME/app/dap-2.env
-source $HOME/app/deploy/envs/hhs.env
-$HOME/app/bin/analytics --publish --frequency=daily --slim --verbose
-$HOME/app/bin/analytics --publish --frequency=daily --slim --verbose --csv
+source $HOME/dap-2.env
+source $HOME/deploy/envs/hhs.env
+$HOME/bin/analytics --publish --frequency=daily --slim --verbose
+$HOME/bin/analytics --publish --frequency=daily --slim --verbose --csv
 
 # Department of Housing and Urban Development
-source $HOME/app/dap-2.env
-source $HOME/app/deploy/envs/hud.env
-$HOME/app/bin/analytics --publish --frequency=daily --slim --verbose
-$HOME/app/bin/analytics --publish --frequency=daily --slim --verbose --csv
+source $HOME/dap-2.env
+source $HOME/deploy/envs/hud.env
+$HOME/bin/analytics --publish --frequency=daily --slim --verbose
+$HOME/bin/analytics --publish --frequency=daily --slim --verbose --csv
 
 # Department of Homeland Security
-source $HOME/app/dap-2.env
-source $HOME/app/deploy/envs/dhs.env
-$HOME/app/bin/analytics --publish --frequency=daily --slim --verbose
-$HOME/app/bin/analytics --publish --frequency=daily --slim --verbose --csv
+source $HOME/dap-2.env
+source $HOME/deploy/envs/dhs.env
+$HOME/bin/analytics --publish --frequency=daily --slim --verbose
+$HOME/bin/analytics --publish --frequency=daily --slim --verbose --csv
 
 # Department of Labor
-source $HOME/app/dap-2.env
-source $HOME/app/deploy/envs/labor.env
-$HOME/app/bin/analytics --publish --frequency=daily --slim --verbose
-$HOME/app/bin/analytics --publish --frequency=daily --slim --verbose --csv
+source $HOME/dap-2.env
+source $HOME/deploy/envs/labor.env
+$HOME/bin/analytics --publish --frequency=daily --slim --verbose
+$HOME/bin/analytics --publish --frequency=daily --slim --verbose --csv
 
 # Department of State
-source $HOME/app/dap-2.env
-source $HOME/app/deploy/envs/state.env
-$HOME/app/bin/analytics --publish --frequency=daily --slim --verbose
-$HOME/app/bin/analytics --publish --frequency=daily --slim --verbose --csv
+source $HOME/dap-2.env
+source $HOME/deploy/envs/state.env
+$HOME/bin/analytics --publish --frequency=daily --slim --verbose
+$HOME/bin/analytics --publish --frequency=daily --slim --verbose --csv
 
 # Department of Transportation
-source $HOME/app/dap-2.env
-source $HOME/app/deploy/envs/transportation.env
-$HOME/app/bin/analytics --publish --frequency=daily --slim --verbose
-$HOME/app/bin/analytics --publish --frequency=daily --slim --verbose --csv
+source $HOME/dap-2.env
+source $HOME/deploy/envs/transportation.env
+$HOME/bin/analytics --publish --frequency=daily --slim --verbose
+$HOME/bin/analytics --publish --frequency=daily --slim --verbose --csv
 
 # Department of the Treasury
-source $HOME/app/dap-2.env
-source $HOME/app/deploy/envs/treasury.env
-$HOME/app/bin/analytics --publish --frequency=daily --slim --verbose
-$HOME/app/bin/analytics --publish --frequency=daily --slim --verbose --csv
+source $HOME/dap-2.env
+source $HOME/deploy/envs/treasury.env
+$HOME/bin/analytics --publish --frequency=daily --slim --verbose
+$HOME/bin/analytics --publish --frequency=daily --slim --verbose --csv
 
 # Agency for International Development
-source $HOME/app/dap-2.env
-source $HOME/app/deploy/envs/usaid.env
-$HOME/app/bin/analytics --publish --frequency=daily --slim --verbose
-$HOME/app/bin/analytics --publish --frequency=daily --slim --verbose --csv
+source $HOME/dap-2.env
+source $HOME/deploy/envs/usaid.env
+$HOME/bin/analytics --publish --frequency=daily --slim --verbose
+$HOME/bin/analytics --publish --frequency=daily --slim --verbose --csv
 
 # General Services Administration
-source $HOME/app/dap-2.env
-source $HOME/app/deploy/envs/gsa.env
-$HOME/app/bin/analytics --publish --frequency=daily --slim --verbose
-$HOME/app/bin/analytics --publish --frequency=daily --slim --verbose --csv
+source $HOME/dap-2.env
+source $HOME/deploy/envs/gsa.env
+$HOME/bin/analytics --publish --frequency=daily --slim --verbose
+$HOME/bin/analytics --publish --frequency=daily --slim --verbose --csv
 
 # National Science Foundation
-source $HOME/app/dap-2.env
-source $HOME/app/deploy/envs/nsf.env
-$HOME/app/bin/analytics --publish --frequency=daily --slim --verbose
-$HOME/app/bin/analytics --publish --frequency=daily --slim --verbose --csv
+source $HOME/dap-2.env
+source $HOME/deploy/envs/nsf.env
+$HOME/bin/analytics --publish --frequency=daily --slim --verbose
+$HOME/bin/analytics --publish --frequency=daily --slim --verbose --csv
 
 # Nuclear Regulatory Commission
-source $HOME/app/dap-2.env
-source $HOME/app/deploy/envs/nrc.env
-$HOME/app/bin/analytics --publish --frequency=daily --slim --verbose
-$HOME/app/bin/analytics --publish --frequency=daily --slim --verbose --csv
+source $HOME/dap-2.env
+source $HOME/deploy/envs/nrc.env
+$HOME/bin/analytics --publish --frequency=daily --slim --verbose
+$HOME/bin/analytics --publish --frequency=daily --slim --verbose --csv
 
 # Office of Personnel Management
-source $HOME/app/dap-2.env
-source $HOME/app/deploy/envs/opm.env
-$HOME/app/bin/analytics --publish --frequency=daily --slim --verbose
-$HOME/app/bin/analytics --publish --frequency=daily --slim --verbose --csv
+source $HOME/dap-2.env
+source $HOME/deploy/envs/opm.env
+$HOME/bin/analytics --publish --frequency=daily --slim --verbose
+$HOME/bin/analytics --publish --frequency=daily --slim --verbose --csv
 
 # Social Security Administration
-source $HOME/app/dap-2.env
-source $HOME/app/deploy/envs/ssa.env
-$HOME/app/bin/analytics --publish --frequency=daily --slim --verbose
-$HOME/app/bin/analytics --publish --frequency=daily --slim --verbose --csv
+source $HOME/dap-2.env
+source $HOME/deploy/envs/ssa.env
+$HOME/bin/analytics --publish --frequency=daily --slim --verbose
+$HOME/bin/analytics --publish --frequency=daily --slim --verbose --csv
 
 # US Postal Service
-source $HOME/app/dap-2.env
-source $HOME/app/deploy/envs/postal-service.env
-$HOME/app/bin/analytics --publish --frequency=daily --slim --verbose
-$HOME/app/bin/analytics --publish --frequency=daily --slim --verbose --csv
+source $HOME/dap-2.env
+source $HOME/deploy/envs/postal-service.env
+$HOME/bin/analytics --publish --frequency=daily --slim --verbose
+$HOME/bin/analytics --publish --frequency=daily --slim --verbose --csv
 
 # Executive Office of the President
-source $HOME/app/dap-2.env
-source $HOME/app/deploy/envs/eop.env
-$HOME/app/bin/analytics --publish --frequency=daily --slim --verbose
-$HOME/app/bin/analytics --publish --frequency=daily --slim --verbose --csv
+source $HOME/dap-2.env
+source $HOME/deploy/envs/eop.env
+$HOME/bin/analytics --publish --frequency=daily --slim --verbose
+$HOME/bin/analytics --publish --frequency=daily --slim --verbose --csv

--- a/deploy/hourly.sh
+++ b/deploy/hourly.sh
@@ -4,140 +4,140 @@ export PATH=$PATH:/usr/local/bin
 source $HOME/.bashrc
 
 # just the one awkward 'today' report
-source $HOME/app/dap-1.env
-$HOME/app/bin/analytics --publish --frequency=hourly --slim --verbose
+source $HOME/dap-1.env
+$HOME/bin/analytics --publish --frequency=hourly --slim --verbose
 
 # ED Reports
-source $HOME/app/dap-1.env
-source $HOME/app/deploy/envs/ed.env
-$HOME/app/bin/analytics --publish --frequency=hourly --slim --verbose
+source $HOME/dap-1.env
+source $HOME/deploy/envs/ed.env
+$HOME/bin/analytics --publish --frequency=hourly --slim --verbose
 
 # NASA Reports
-source $HOME/app/dap-1.env
-source $HOME/app/deploy/envs/nasa.env
-$HOME/app/bin/analytics --publish --frequency=hourly --slim --verbose
+source $HOME/dap-1.env
+source $HOME/deploy/envs/nasa.env
+$HOME/bin/analytics --publish --frequency=hourly --slim --verbose
 
 # DOJ Reports
-source $HOME/app/dap-1.env
-source $HOME/app/deploy/envs/doj.env
-$HOME/app/bin/analytics --publish --frequency=hourly --slim --verbose
+source $HOME/dap-1.env
+source $HOME/deploy/envs/doj.env
+$HOME/bin/analytics --publish --frequency=hourly --slim --verbose
 
 # VA Reports
-source $HOME/app/dap-1.env
-source $HOME/app/deploy/envs/va.env
-$HOME/app/bin/analytics --publish --frequency=hourly --slim --verbose
+source $HOME/dap-1.env
+source $HOME/deploy/envs/va.env
+$HOME/bin/analytics --publish --frequency=hourly --slim --verbose
 
 # Commerce Reports
-source $HOME/app/dap-1.env
-source $HOME/app/deploy/envs/commerce.env
-$HOME/app/bin/analytics --publish --frequency=hourly --slim --verbose
+source $HOME/dap-1.env
+source $HOME/deploy/envs/commerce.env
+$HOME/bin/analytics --publish --frequency=hourly --slim --verbose
 
 # EPA Reports
-source $HOME/app/dap-1.env
-source $HOME/app/deploy/envs/epa.env
-$HOME/app/bin/analytics --publish --frequency=hourly --slim --verbose
+source $HOME/dap-1.env
+source $HOME/deploy/envs/epa.env
+$HOME/bin/analytics --publish --frequency=hourly --slim --verbose
 
 # SBA Reports
-source $HOME/app/dap-1.env
-source $HOME/app/deploy/envs/sba.env
-$HOME/app/bin/analytics --publish --frequency=hourly --slim --verbose
+source $HOME/dap-1.env
+source $HOME/deploy/envs/sba.env
+$HOME/bin/analytics --publish --frequency=hourly --slim --verbose
 
 # Energy Reports
-source $HOME/app/dap-1.env
-source $HOME/app/deploy/envs/energy.env
-$HOME/app/bin/analytics --publish --frequency=hourly --slim --verbose
+source $HOME/dap-1.env
+source $HOME/deploy/envs/energy.env
+$HOME/bin/analytics --publish --frequency=hourly --slim --verbose
 
 # DOI Reports
-source $HOME/app/dap-1.env
-source $HOME/app/deploy/envs/doi.env
-$HOME/app/bin/analytics --publish --frequency=hourly --slim --verbose
+source $HOME/dap-1.env
+source $HOME/deploy/envs/doi.env
+$HOME/bin/analytics --publish --frequency=hourly --slim --verbose
 
 # NARA Reports
-source $HOME/app/dap-1.env
-source $HOME/app/deploy/envs/nara.env
-$HOME/app/bin/analytics --publish --frequency=hourly --slim --verbose
+source $HOME/dap-1.env
+source $HOME/deploy/envs/nara.env
+$HOME/bin/analytics --publish --frequency=hourly --slim --verbose
 
 # Department of Agriculture
-source $HOME/app/dap-1.env
-source $HOME/app/deploy/envs/agriculture.env
-$HOME/app/bin/analytics --publish --frequency=hourly --slim --verbose
+source $HOME/dap-1.env
+source $HOME/deploy/envs/agriculture.env
+$HOME/bin/analytics --publish --frequency=hourly --slim --verbose
 
 # Department of Defense
-source $HOME/app/dap-1.env
-source $HOME/app/deploy/envs/defense.env
-$HOME/app/bin/analytics --publish --frequency=hourly --slim --verbose
+source $HOME/dap-1.env
+source $HOME/deploy/envs/defense.env
+$HOME/bin/analytics --publish --frequency=hourly --slim --verbose
 
 # Department of Health and Human Services
-source $HOME/app/dap-2.env
-source $HOME/app/deploy/envs/hhs.env
-$HOME/app/bin/analytics --publish --frequency=hourly --slim --verbose
+source $HOME/dap-2.env
+source $HOME/deploy/envs/hhs.env
+$HOME/bin/analytics --publish --frequency=hourly --slim --verbose
 
 # Department of Housing and Urban Development
-source $HOME/app/dap-2.env
-source $HOME/app/deploy/envs/hud.env
-$HOME/app/bin/analytics --publish --frequency=hourly --slim --verbose
+source $HOME/dap-2.env
+source $HOME/deploy/envs/hud.env
+$HOME/bin/analytics --publish --frequency=hourly --slim --verbose
 
 # Department of Homeland Security
-source $HOME/app/dap-2.env
-source $HOME/app/deploy/envs/dhs.env
-$HOME/app/bin/analytics --publish --frequency=hourly --slim --verbose
+source $HOME/dap-2.env
+source $HOME/deploy/envs/dhs.env
+$HOME/bin/analytics --publish --frequency=hourly --slim --verbose
 
 # Department of Labor
-source $HOME/app/dap-2.env
-source $HOME/app/deploy/envs/labor.env
-$HOME/app/bin/analytics --publish --frequency=hourly --slim --verbose
+source $HOME/dap-2.env
+source $HOME/deploy/envs/labor.env
+$HOME/bin/analytics --publish --frequency=hourly --slim --verbose
 
 # Department of State
-source $HOME/app/dap-2.env
-source $HOME/app/deploy/envs/state.env
-$HOME/app/bin/analytics --publish --frequency=hourly --slim --verbose
+source $HOME/dap-2.env
+source $HOME/deploy/envs/state.env
+$HOME/bin/analytics --publish --frequency=hourly --slim --verbose
 
 # Department of Transportation
-source $HOME/app/dap-2.env
-source $HOME/app/deploy/envs/transportation.env
-$HOME/app/bin/analytics --publish --frequency=hourly --slim --verbose
+source $HOME/dap-2.env
+source $HOME/deploy/envs/transportation.env
+$HOME/bin/analytics --publish --frequency=hourly --slim --verbose
 
 # Department of the Treasury
-source $HOME/app/dap-2.env
-source $HOME/app/deploy/envs/treasury.env
-$HOME/app/bin/analytics --publish --frequency=hourly --slim --verbose
+source $HOME/dap-2.env
+source $HOME/deploy/envs/treasury.env
+$HOME/bin/analytics --publish --frequency=hourly --slim --verbose
 
 # Agency for International Development
-source $HOME/app/dap-2.env
-source $HOME/app/deploy/envs/usaid.env
-$HOME/app/bin/analytics --publish --frequency=hourly --slim --verbose
+source $HOME/dap-2.env
+source $HOME/deploy/envs/usaid.env
+$HOME/bin/analytics --publish --frequency=hourly --slim --verbose
 
 # General Services Administration
-source $HOME/app/dap-2.env
-source $HOME/app/deploy/envs/gsa.env
-$HOME/app/bin/analytics --publish --frequency=hourly --slim --verbose
+source $HOME/dap-2.env
+source $HOME/deploy/envs/gsa.env
+$HOME/bin/analytics --publish --frequency=hourly --slim --verbose
 
 # National Science Foundation
-source $HOME/app/dap-2.env
-source $HOME/app/deploy/envs/nsf.env
-$HOME/app/bin/analytics --publish --frequency=hourly --slim --verbose
+source $HOME/dap-2.env
+source $HOME/deploy/envs/nsf.env
+$HOME/bin/analytics --publish --frequency=hourly --slim --verbose
 
 # Nuclear Regulatory Commission
-source $HOME/app/dap-2.env
-source $HOME/app/deploy/envs/nrc.env
-$HOME/app/bin/analytics --publish --frequency=hourly --slim --verbose
+source $HOME/dap-2.env
+source $HOME/deploy/envs/nrc.env
+$HOME/bin/analytics --publish --frequency=hourly --slim --verbose
 
 # Office of Personnel Management
-source $HOME/app/dap-2.env
-source $HOME/app/deploy/envs/opm.env
-$HOME/app/bin/analytics --publish --frequency=hourly --slim --verbose
+source $HOME/dap-2.env
+source $HOME/deploy/envs/opm.env
+$HOME/bin/analytics --publish --frequency=hourly --slim --verbose
 
 # Social Security Administration
-source $HOME/app/dap-2.env
-source $HOME/app/deploy/envs/ssa.env
-$HOME/app/bin/analytics --publish --frequency=hourly --slim --verbose
+source $HOME/dap-2.env
+source $HOME/deploy/envs/ssa.env
+$HOME/bin/analytics --publish --frequency=hourly --slim --verbose
 
 # US Postal Service
-source $HOME/app/dap-2.env
-source $HOME/app/deploy/envs/postal-service.env
-$HOME/app/bin/analytics --publish --frequency=hourly --slim --verbose
+source $HOME/dap-2.env
+source $HOME/deploy/envs/postal-service.env
+$HOME/bin/analytics --publish --frequency=hourly --slim --verbose
 
 # Executive Office of the President
-source $HOME/app/dap-2.env
-source $HOME/app/deploy/envs/eop.env
-$HOME/app/bin/analytics --publish --frequency=hourly --slim --verbose
+source $HOME/dap-2.env
+source $HOME/deploy/envs/eop.env
+$HOME/bin/analytics --publish --frequency=hourly --slim --verbose

--- a/deploy/realtime.sh
+++ b/deploy/realtime.sh
@@ -3,170 +3,170 @@
 export PATH=$PATH:/usr/local/bin
 source $HOME/.bashrc
 
-source $HOME/app/dap-1.env
-$HOME/app/bin/analytics --publish --frequency=realtime --slim --verbose
+source $HOME/dap-1.env
+$HOME/bin/analytics --publish --frequency=realtime --slim --verbose
 # we want just one realtime report in CSV, hardcoded for now to save on API requests
-$HOME/app/bin/analytics --publish --only=all-pages-realtime --slim --verbose --csv
+$HOME/bin/analytics --publish --only=all-pages-realtime --slim --verbose --csv
 
 # ED reports
-source $HOME/app/dap-1.env
-source $HOME/app/deploy/envs/ed.env
-$HOME/app/bin/analytics --publish --frequency=realtime --slim --verbose
-$HOME/app/bin/analytics --publish --only=all-pages-realtime --slim --verbose --csv
+source $HOME/dap-1.env
+source $HOME/deploy/envs/ed.env
+$HOME/bin/analytics --publish --frequency=realtime --slim --verbose
+$HOME/bin/analytics --publish --only=all-pages-realtime --slim --verbose --csv
 
 # VA reports
-source $HOME/app/dap-1.env
-source $HOME/app/deploy/envs/va.env
-$HOME/app/bin/analytics --publish --frequency=realtime --slim --verbose
-$HOME/app/bin/analytics --publish --only=all-pages-realtime --slim --verbose --csv
+source $HOME/dap-1.env
+source $HOME/deploy/envs/va.env
+$HOME/bin/analytics --publish --frequency=realtime --slim --verbose
+$HOME/bin/analytics --publish --only=all-pages-realtime --slim --verbose --csv
 
 # NASA reports
-source $HOME/app/dap-1.env
-source $HOME/app/deploy/envs/nasa.env
-$HOME/app/bin/analytics --publish --frequency=realtime --slim --verbose
-$HOME/app/bin/analytics --publish --only=all-pages-realtime --slim --verbose --csv
+source $HOME/dap-1.env
+source $HOME/deploy/envs/nasa.env
+$HOME/bin/analytics --publish --frequency=realtime --slim --verbose
+$HOME/bin/analytics --publish --only=all-pages-realtime --slim --verbose --csv
 
 # DOJ reports
-source $HOME/app/dap-1.env
-source $HOME/app/deploy/envs/doj.env
-$HOME/app/bin/analytics --publish --frequency=realtime --slim --verbose
-$HOME/app/bin/analytics --publish --only=all-pages-realtime --slim --verbose --csv
+source $HOME/dap-1.env
+source $HOME/deploy/envs/doj.env
+$HOME/bin/analytics --publish --frequency=realtime --slim --verbose
+$HOME/bin/analytics --publish --only=all-pages-realtime --slim --verbose --csv
 
 # Commerce reports
-source $HOME/app/dap-1.env
-source $HOME/app/deploy/envs/commerce.env
-$HOME/app/bin/analytics --publish --frequency=realtime --slim --verbose
-$HOME/app/bin/analytics --publish --only=all-pages-realtime --slim --verbose --csv
+source $HOME/dap-1.env
+source $HOME/deploy/envs/commerce.env
+$HOME/bin/analytics --publish --frequency=realtime --slim --verbose
+$HOME/bin/analytics --publish --only=all-pages-realtime --slim --verbose --csv
 
 
 # EPA reports
-source $HOME/app/dap-1.env
-source $HOME/app/deploy/envs/epa.env
-$HOME/app/bin/analytics --publish --frequency=realtime --slim --verbose
-$HOME/app/bin/analytics --publish --only=all-pages-realtime --slim --verbose --csv
+source $HOME/dap-1.env
+source $HOME/deploy/envs/epa.env
+$HOME/bin/analytics --publish --frequency=realtime --slim --verbose
+$HOME/bin/analytics --publish --only=all-pages-realtime --slim --verbose --csv
 
 # sba reports
-source $HOME/app/dap-1.env
-source $HOME/app/deploy/envs/sba.env
-$HOME/app/bin/analytics --publish --frequency=realtime --slim --verbose
-$HOME/app/bin/analytics --publish --only=all-pages-realtime --slim --verbose --csv
+source $HOME/dap-1.env
+source $HOME/deploy/envs/sba.env
+$HOME/bin/analytics --publish --frequency=realtime --slim --verbose
+$HOME/bin/analytics --publish --only=all-pages-realtime --slim --verbose --csv
 
 # Energy reports
-source $HOME/app/dap-1.env
-source $HOME/app/deploy/envs/energy.env
-$HOME/app/bin/analytics --publish --frequency=realtime --slim --verbose
-$HOME/app/bin/analytics --publish --only=all-pages-realtime --slim --verbose --csv
+source $HOME/dap-1.env
+source $HOME/deploy/envs/energy.env
+$HOME/bin/analytics --publish --frequency=realtime --slim --verbose
+$HOME/bin/analytics --publish --only=all-pages-realtime --slim --verbose --csv
 
 # DOI reports
-source $HOME/app/dap-1.env
-source $HOME/app/deploy/envs/doi.env
-$HOME/app/bin/analytics --publish --frequency=realtime --slim --verbose
-$HOME/app/bin/analytics --publish --only=all-pages-realtime --slim --verbose --csv
+source $HOME/dap-1.env
+source $HOME/deploy/envs/doi.env
+$HOME/bin/analytics --publish --frequency=realtime --slim --verbose
+$HOME/bin/analytics --publish --only=all-pages-realtime --slim --verbose --csv
 
 # NARA reports
-source $HOME/app/dap-1.env
-source $HOME/app/deploy/envs/nara.env
-$HOME/app/bin/analytics --publish --frequency=realtime --slim --verbose
-$HOME/app/bin/analytics --publish --only=all-pages-realtime --slim --verbose --csv
+source $HOME/dap-1.env
+source $HOME/deploy/envs/nara.env
+$HOME/bin/analytics --publish --frequency=realtime --slim --verbose
+$HOME/bin/analytics --publish --only=all-pages-realtime --slim --verbose --csv
 
 # Department of Agriculture
-source $HOME/app/dap-1.env
-source $HOME/app/deploy/envs/agriculture.env
-$HOME/app/bin/analytics --publish --frequency=realtime --slim --verbose
-$HOME/app/bin/analytics --publish --only=all-pages-realtime --slim --verbose --csv
+source $HOME/dap-1.env
+source $HOME/deploy/envs/agriculture.env
+$HOME/bin/analytics --publish --frequency=realtime --slim --verbose
+$HOME/bin/analytics --publish --only=all-pages-realtime --slim --verbose --csv
 
 # Department of Defense
-source $HOME/app/dap-1.env
-source $HOME/app/deploy/envs/defense.env
-$HOME/app/bin/analytics --publish --frequency=realtime --slim --verbose
-$HOME/app/bin/analytics --publish --only=all-pages-realtime --slim --verbose --csv
+source $HOME/dap-1.env
+source $HOME/deploy/envs/defense.env
+$HOME/bin/analytics --publish --frequency=realtime --slim --verbose
+$HOME/bin/analytics --publish --only=all-pages-realtime --slim --verbose --csv
 
 # Department of Health and Human Services
-source $HOME/app/dap-2.env
-source $HOME/app/deploy/envs/hhs.env
-$HOME/app/bin/analytics --publish --frequency=realtime --slim --verbose
-$HOME/app/bin/analytics --publish --only=all-pages-realtime --slim --verbose --csv
+source $HOME/dap-2.env
+source $HOME/deploy/envs/hhs.env
+$HOME/bin/analytics --publish --frequency=realtime --slim --verbose
+$HOME/bin/analytics --publish --only=all-pages-realtime --slim --verbose --csv
 
 # Department of Housing and Urban Development
-source $HOME/app/dap-2.env
-source $HOME/app/deploy/envs/hud.env
-$HOME/app/bin/analytics --publish --frequency=realtime --slim --verbose
-$HOME/app/bin/analytics --publish --only=all-pages-realtime --slim --verbose --csv
+source $HOME/dap-2.env
+source $HOME/deploy/envs/hud.env
+$HOME/bin/analytics --publish --frequency=realtime --slim --verbose
+$HOME/bin/analytics --publish --only=all-pages-realtime --slim --verbose --csv
 
 # Department of Homeland Security
-source $HOME/app/dap-2.env
-source $HOME/app/deploy/envs/dhs.env
-$HOME/app/bin/analytics --publish --frequency=realtime --slim --verbose
-$HOME/app/bin/analytics --publish --only=all-pages-realtime --slim --verbose --csv
+source $HOME/dap-2.env
+source $HOME/deploy/envs/dhs.env
+$HOME/bin/analytics --publish --frequency=realtime --slim --verbose
+$HOME/bin/analytics --publish --only=all-pages-realtime --slim --verbose --csv
 
 # Department of Labor
-source $HOME/app/dap-2.env
-source $HOME/app/deploy/envs/labor.env
-$HOME/app/bin/analytics --publish --frequency=realtime --slim --verbose
-$HOME/app/bin/analytics --publish --only=all-pages-realtime --slim --verbose --csv
+source $HOME/dap-2.env
+source $HOME/deploy/envs/labor.env
+$HOME/bin/analytics --publish --frequency=realtime --slim --verbose
+$HOME/bin/analytics --publish --only=all-pages-realtime --slim --verbose --csv
 
 # Department of State
-source $HOME/app/dap-2.env
-source $HOME/app/deploy/envs/state.env
-$HOME/app/bin/analytics --publish --frequency=realtime --slim --verbose
-$HOME/app/bin/analytics --publish --only=all-pages-realtime --slim --verbose --csv
+source $HOME/dap-2.env
+source $HOME/deploy/envs/state.env
+$HOME/bin/analytics --publish --frequency=realtime --slim --verbose
+$HOME/bin/analytics --publish --only=all-pages-realtime --slim --verbose --csv
 
 # Department of Transportation
-source $HOME/app/dap-2.env
-source $HOME/app/deploy/envs/transportation.env
-$HOME/app/bin/analytics --publish --frequency=realtime --slim --verbose
-$HOME/app/bin/analytics --publish --only=all-pages-realtime --slim --verbose --csv
+source $HOME/dap-2.env
+source $HOME/deploy/envs/transportation.env
+$HOME/bin/analytics --publish --frequency=realtime --slim --verbose
+$HOME/bin/analytics --publish --only=all-pages-realtime --slim --verbose --csv
 
 # Department of the Treasury
-source $HOME/app/dap-2.env
-source $HOME/app/deploy/envs/treasury.env
-$HOME/app/bin/analytics --publish --frequency=realtime --slim --verbose
-$HOME/app/bin/analytics --publish --only=all-pages-realtime --slim --verbose --csv
+source $HOME/dap-2.env
+source $HOME/deploy/envs/treasury.env
+$HOME/bin/analytics --publish --frequency=realtime --slim --verbose
+$HOME/bin/analytics --publish --only=all-pages-realtime --slim --verbose --csv
 
 # Agency for International Development
-source $HOME/app/dap-2.env
-source $HOME/app/deploy/envs/usaid.env
-$HOME/app/bin/analytics --publish --frequency=realtime --slim --verbose
-$HOME/app/bin/analytics --publish --only=all-pages-realtime --slim --verbose --csv
+source $HOME/dap-2.env
+source $HOME/deploy/envs/usaid.env
+$HOME/bin/analytics --publish --frequency=realtime --slim --verbose
+$HOME/bin/analytics --publish --only=all-pages-realtime --slim --verbose --csv
 
 # General Services Administration
-source $HOME/app/dap-2.env
-source $HOME/app/deploy/envs/gsa.env
-$HOME/app/bin/analytics --publish --frequency=realtime --slim --verbose
-$HOME/app/bin/analytics --publish --only=all-pages-realtime --slim --verbose --csv
+source $HOME/dap-2.env
+source $HOME/deploy/envs/gsa.env
+$HOME/bin/analytics --publish --frequency=realtime --slim --verbose
+$HOME/bin/analytics --publish --only=all-pages-realtime --slim --verbose --csv
 
 # National Science Foundation
-source $HOME/app/dap-2.env
-source $HOME/app/deploy/envs/nsf.env
-$HOME/app/bin/analytics --publish --frequency=realtime --slim --verbose
-$HOME/app/bin/analytics --publish --only=all-pages-realtime --slim --verbose --csv
+source $HOME/dap-2.env
+source $HOME/deploy/envs/nsf.env
+$HOME/bin/analytics --publish --frequency=realtime --slim --verbose
+$HOME/bin/analytics --publish --only=all-pages-realtime --slim --verbose --csv
 
 # Nuclear Regulatory Commission
-source $HOME/app/dap-2.env
-source $HOME/app/deploy/envs/nrc.env
-$HOME/app/bin/analytics --publish --frequency=realtime --slim --verbose
-$HOME/app/bin/analytics --publish --only=all-pages-realtime --slim --verbose --csv
+source $HOME/dap-2.env
+source $HOME/deploy/envs/nrc.env
+$HOME/bin/analytics --publish --frequency=realtime --slim --verbose
+$HOME/bin/analytics --publish --only=all-pages-realtime --slim --verbose --csv
 
 # Office of Personnel Management
-source $HOME/app/dap-2.env
-source $HOME/app/deploy/envs/opm.env
-$HOME/app/bin/analytics --publish --frequency=realtime --slim --verbose
-$HOME/app/bin/analytics --publish --only=all-pages-realtime --slim --verbose --csv
+source $HOME/dap-2.env
+source $HOME/deploy/envs/opm.env
+$HOME/bin/analytics --publish --frequency=realtime --slim --verbose
+$HOME/bin/analytics --publish --only=all-pages-realtime --slim --verbose --csv
 
 # Social Security Administration
-source $HOME/app/dap-2.env
-source $HOME/app/deploy/envs/ssa.env
-$HOME/app/bin/analytics --publish --frequency=realtime --slim --verbose
-$HOME/app/bin/analytics --publish --only=all-pages-realtime --slim --verbose --csv
+source $HOME/dap-2.env
+source $HOME/deploy/envs/ssa.env
+$HOME/bin/analytics --publish --frequency=realtime --slim --verbose
+$HOME/bin/analytics --publish --only=all-pages-realtime --slim --verbose --csv
 
 # US Postal Service
-source $HOME/app/dap-2.env
-source $HOME/app/deploy/envs/postal-service.env
-$HOME/app/bin/analytics --publish --frequency=realtime --slim --verbose
-$HOME/app/bin/analytics --publish --only=all-pages-realtime --slim --verbose --csv
+source $HOME/dap-2.env
+source $HOME/deploy/envs/postal-service.env
+$HOME/bin/analytics --publish --frequency=realtime --slim --verbose
+$HOME/bin/analytics --publish --only=all-pages-realtime --slim --verbose --csv
 
 # Executive Office of the President
-source $HOME/app/dap-2.env
-source $HOME/app/deploy/envs/eop.env
-$HOME/app/bin/analytics --publish --frequency=realtime --slim --verbose
-$HOME/app/bin/analytics --publish --only=all-pages-realtime --slim --verbose --csv
+source $HOME/dap-2.env
+source $HOME/deploy/envs/eop.env
+$HOME/bin/analytics --publish --frequency=realtime --slim --verbose
+$HOME/bin/analytics --publish --only=all-pages-realtime --slim --verbose --csv


### PR DESCRIPTION
There were some issues with the way paths were managed in cloud.gov.
This commit has some fixes for those.

The `$HOME` directory was expected to be `/home/vcap`, but it looks like
that is `/home/vcap/app` when the app is started. This commit changes
the `daily.sh`, `hourly.sh`, and `realtime.sh` to use the correct
directory in response to that.

This commit also changes the line count output in `cron.js` so that it
uses the correct path when looking for the log files. This was causing
the app to crash beforehand.

Finally, this commit updates `cron.js` so that is uses the correct
relative paths when looking for the scripts that generate the reports.