### PR TITLE
Log line count results in cron.js

### DIFF
--- a/deploy/cron.js
+++ b/deploy/cron.js
@@ -9,7 +9,7 @@ var daily_run = function(){
 			return;
 		}
 		console.log("number of lines in daily.log:");
-		execSync("wc -l ../logs/daily.log");
+		console.log(execSync("wc -l ../logs/daily.log").toString());
 		console.log(`${stdout}`);
 		console.log(`stderr: ${stderr}`);
 	});
@@ -23,7 +23,7 @@ var hourly_run = function(){
 			return;
 		}
 		console.log("number of lines in hourly.log:");
-		execSync("wc -l ../logs/hourly.log");
+		console.log(execSync("wc -l ../logs/hourly.log").toString());
 		console.log(`${stdout}`);
 		console.log(`stderr: ${stderr}`);
 	});
@@ -37,7 +37,7 @@ var realtime_run = function(){
 			return;
 		}
 		console.log("number of lines in realtime.log:");
-		execSync("wc -l ../logs/realtime.log");
+		console.log(execSync("wc -l ../logs/realtime.log").toString());
 		console.log(`${stdout}`);
 		console.log(`stderr: ${stderr}`);
 	});


### PR DESCRIPTION
This commit logs the output for line counts in cron.js. Before the command to count the lines was being called, but the result was never being outputed so the logs were not picking it up.