### PR TITLE
Add New Relic

### DIFF
--- a/deploy/cron.js
+++ b/deploy/cron.js
@@ -1,4 +1,4 @@
-if (process.env.NODE_ENV === "production") {
+if (process.env.NEW_RELIC_APP_NAME) {
 	console.log("Starting New Relic")
 	require("newrelic")
 }

--- a/deploy/cron.js
+++ b/deploy/cron.js
@@ -1,3 +1,8 @@
+if (process.env.NODE_ENV === "production") {
+	console.log("Starting New Relic")
+	require("newrelic")
+}
+
 const spawn = require("child_process").exec;
 const execSync = require("child_process").execSync;
 

--- a/manifest.yml
+++ b/manifest.yml
@@ -24,6 +24,7 @@ applications:
   services:
   - analytics-s3
   - analytics-env
+  - analytics-reporter-new-relic
   stack: cflinuxfs2
   timeout: 180
   path: .

--- a/manifest.yml
+++ b/manifest.yml
@@ -24,7 +24,6 @@ applications:
   services:
   - analytics-s3
   - analytics-env
-  - analytics-reporter-new-relic
   stack: cflinuxfs2
   timeout: 180
   path: .

--- a/newrelic.js
+++ b/newrelic.js
@@ -1,11 +1,7 @@
-const cfenv = require("cfenv")
-const appEnv = cfenv.getAppEnv()
-const newRelicEnv = appEnv.getServiceCreds("analytics-reporter-new-relic")
-
 exports.config = {
-  app_name: [newRelicEnv.APP_NAME],
-  license_key: newRelicEnv.LICENSE_KEY,
+  app_name: [process.env.NEW_RELIC_APP_NAME],
+  license_key: process.env.NEW_RELIC_LICENSE_KEY,
   logging: {
     level: "info"
-  }
+  },
 }

--- a/newrelic.js
+++ b/newrelic.js
@@ -1,0 +1,11 @@
+const cfenv = require("cfenv")
+const appEnv = cfenv.getAppEnv()
+const newRelicEnv = appEnv.getServiceCreds("analytics-reporter-new-relic")
+
+exports.config = {
+  app_name: [newRelicEnv.APP_NAME],
+  license_key: newRelicEnv.LICENSE_KEY,
+  logging: {
+    level: "info"
+  }
+}

--- a/package.json
+++ b/package.json
@@ -57,17 +57,18 @@
   "dependencies": {
     "async": "*",
     "aws-sdk": "*",
-    "cfenv": "^1.0.3",
     "fast-csv": "*",
     "googleapis": "^2.1.5",
     "lodash": "^3.10.1",
     "minimist": "*",
-    "newrelic": "^1.36.1",
     "node-schedule": "^0.1.13"
   },
   "devDependencies": {
     "body-parser": "~1.8.1",
     "express": "~4.9.0",
     "ejs": "~2.3.1"
+  },
+  "optionalDependencies": {
+    "newrelic": "^1.36.1"
   }
 }

--- a/package.json
+++ b/package.json
@@ -2,7 +2,10 @@
   "name": "analytics-reporter",
   "version": "1.1.2",
   "description": "A lightweight command line tool for reporting and publishing analytics data from a Google Analytics account.",
-  "keywords": ["analytics", "google analytics"],
+  "keywords": [
+    "analytics",
+    "google analytics"
+  ],
   "homepage": "https://github.com/18F/analytics-reporter",
   "license": "CC0-1.0",
   "scripts": {
@@ -23,17 +26,22 @@
       "email": "lauren.ancona@phila.gov"
     },
     {
-	"name": "Eric Schles",
-	"email":"eric.schles@gsa.gov"
+      "name": "Eric Schles",
+      "email": "eric.schles@gsa.gov"
     }
   ],
   "files": [
-    "bin", "test", "reports",
-    "analytics.js", "config.js",
+    "bin",
+    "test",
+    "reports",
+    "analytics.js",
+    "config.js",
     "package.json",
     "*.md"
   ],
-  "engines": {"node": ">=0.10.0"},
+  "engines": {
+    "node": ">=0.10.0"
+  },
   "preferGlobal": true,
   "main": "analytics",
   "bin": {
@@ -47,13 +55,15 @@
     "url": "https://github.com/18F/analytics-reporter/issues"
   },
   "dependencies": {
-    "googleapis": "^2.1.5",
-    "node-schedule": "^0.1.13",
-    "minimist": "*",
     "async": "*",
     "aws-sdk": "*",
+    "cfenv": "^1.0.3",
     "fast-csv": "*",
-    "lodash": "^3.10.1"
+    "googleapis": "^2.1.5",
+    "lodash": "^3.10.1",
+    "minimist": "*",
+    "newrelic": "^1.36.1",
+    "node-schedule": "^0.1.13"
   },
   "devDependencies": {
     "body-parser": "~1.8.1",
@@ -61,5 +71,3 @@
     "ejs": "~2.3.1"
   }
 }
-
-   


### PR DESCRIPTION
This commit adds New Relic for the analytics reporter. It is configured to use an App Name and License Key provided by a cloud.gov user provided service named "analytics-reporter-new-relic".

Additionally, I added a `NODE_ENV` environment variable in production to enable the activation of New Relic in production only.

ref 18f/analytics.usa.gov#428