### PR TITLE
Use process health check

### DIFF
--- a/manifest.yml
+++ b/manifest.yml
@@ -4,6 +4,7 @@ applications:
   memory: 512M
   disk_quota: 1024M
   no-route: true
+  health-check-type: process
   buildpack: https://github.com/cloudfoundry/nodejs-buildpack
   command: node deploy/cron.js
   # These are examples. These variables are set via `cg-toolkit/generate-env.sh`


### PR DESCRIPTION
Health check process instead of port: https://docs.cloudfoundry.org/devguide/deploy-apps/manifest.html#health-check-type. Necessary for no-route apps on govcloud.