### PR TITLE
Run daily reports at 5AM ET

### DIFF
--- a/deploy/cron.js
+++ b/deploy/cron.js
@@ -57,7 +57,17 @@ daily_run();
 hourly_run();
 realtime_run();
 //daily
-setInterval(daily_run,1000 * 60 * 60 * 24);
+const currentTime = new Date();
+const nextRunTime = new Date(
+	currentTime.getFullYear(),
+	currentTime.getMonth(),
+	currentTime.getDate() + 1,
+	10 - currentTime.getTimezoneOffset() / 60
+);
+setInterval(() => {
+	daily_run();
+	setInterval(daily_run, 1000 * 60 * 60 * 24);
+}, nextRunTime - currentTime);
 //hourly
 setInterval(hourly_run,1000 * 60 * 60);
 //realtime


### PR DESCRIPTION
This commit configures cron.js so it runs daily reports at 5:00 AM ET.
Prior to this commit, these reports would run at whatever time the app
was started + 24 hours * n. This meant that if the app was started late
in the day, like at 8 PM, the reports would not update until 8 PM.

This commit changes cron.js so that it:

- Runs the daily report
- Calculates the interval between now and 5:00 AM ET tomorrow
- Run the daily report after the interval calculate above has elapsed
- Runs the daily report every 24 hours after running it in the above step