### PR TITLE
Add a module that loads GA credentials on a rotation

### DIFF
--- a/README.md
+++ b/README.md
@@ -66,6 +66,21 @@ export ANALYTICS_KEY="-----BEGIN PRIVATE KEY-----
 "
 ```
 
+If you have multiple accounts for a profile, you can set the `ANALYTICS_CREDENTIALS` variable with a JSON encoded array of those credentials and they'll be used to authorize API requests in a round-robin style.
+
+```
+export ANALYTICS_CREDENTIALS='[
+  {
+    "key": "-----BEGIN PRIVATE KEY-----\n[contents of key]\n-----END PRIVATE KEY-----",
+    "email": "email_1@example.com"
+  },
+  {
+    "key": "-----BEGIN PRIVATE KEY-----\n[contents of key]\n-----END PRIVATE KEY-----",
+    "email": "email_2@example.com"
+  }
+]'
+```
+
 * Make sure your computer or server is syncing its time with the world over NTP. Your computer's time will need to match those on Google's servers for the authentication to work.
 
 * Test your configuration by printing a report to STDOUT:

--- a/env.example
+++ b/env.example
@@ -1,6 +1,16 @@
 export ANALYTICS_REPORT_EMAIL="YYYYYYY@developer.gserviceaccount.com"
 export ANALYTICS_REPORT_IDS="ga:XXXXXX"
-export ANALYTICS_KEY_PATH="/path/to/secret_key.json"
+
+export ANALYTICS_CREDENTIALS='[
+  {
+    "key": "{PRIVATE 1 KEY HERE}",
+    "email": "email_1@example.com"
+  },
+  {
+    "key": "{PRIVATE 2 KEY HERE}",
+    "email": "email_2@example.com"
+  }
+]'
 
 # Optional: if your profile uses a single hostname, set it here.
 # It will be prepended to page paths.

--- a/src/config.js
+++ b/src/config.js
@@ -5,6 +5,7 @@ module.exports = {
   email: process.env.ANALYTICS_REPORT_EMAIL,
   key: process.env.ANALYTICS_KEY,
   key_file: process.env.ANALYTICS_KEY_PATH,
+  analytics_credentials: process.env.ANALYTICS_CREDENTIALS,
 
   reports_file: process.env.ANALYTICS_REPORTS_PATH,
 

--- a/src/load-ga-credentials.js
+++ b/src/load-ga-credentials.js
@@ -1,0 +1,20 @@
+const config = require("./config")
+
+global.analyticsCredentialsIndex = 0
+
+const loadGoogleAnalyticsCredentials = () => {
+  const credentialData = JSON.parse(config.analytics_credentials)
+  const credentialsArray = _wrapArray(credentialData)
+  const index = global.analyticsCredentialsIndex++ % credentialsArray.length
+  return credentialsArray[index]
+}
+
+const _wrapArray = (object) => {
+  if (Array.isArray(object)) {
+    return object
+  } else {
+    return [object]
+  }
+}
+
+module.exports = loadGoogleAnalyticsCredentials

--- a/test/fixtures/secret_key.json
+++ b/test/fixtures/secret_key.json
@@ -1,7 +1,7 @@
 {
   "private_key_id": "123abc",
   "private_key": "json-key-file-not-actually-a-secret-key",
-  "client_email": "test_email@example.com",
+  "client_email": "json_test_email@example.com",
   "client_id": "789ghi.apps.googleusercontent.com",
   "type": "service_account"
 }

--- a/test/load-next-ga-credential.test.js
+++ b/test/load-next-ga-credential.test.js
@@ -1,0 +1,52 @@
+const expect = require("chai").expect
+const proxyquire = require("proxyquire")
+
+proxyquire.noCallThru()
+
+const config = {}
+
+const loadGoogleAnalyticsCredentials = proxyquire("../src/load-ga-credentials", {
+  "./config": config,
+})
+
+describe(".loadGoogleAnalyticsCredentials", () => {
+  beforeEach(() => {
+    config.analytics_credentials = undefined
+    global.analyticsCredentialsIndex = 0
+  })
+
+  it("should return the credentials if the credentials are an object", () => {
+    config.analytics_credentials = `{
+      "email": "email@example.com",
+      "key": "this-is-a-secret"
+    }`
+
+    const creds = loadGoogleAnalyticsCredentials()
+    expect(creds.email).to.equal("email@example.com")
+    expect(creds.key).to.equal("this-is-a-secret")
+  })
+
+  it("should return successive credentials if the credentials are an array", () => {
+    config.analytics_credentials = `[
+      {
+        "email": "email_1@example.com",
+        "key": "this-is-a-secret-1"
+      },
+      {
+        "email": "email_2@example.com",
+        "key": "this-is-a-secret-2"
+      }
+    ]`
+
+    const firstCreds = loadGoogleAnalyticsCredentials()
+    const secondCreds = loadGoogleAnalyticsCredentials()
+    const thirdCreds = loadGoogleAnalyticsCredentials()
+
+    expect(firstCreds.email).to.equal("email_1@example.com")
+    expect(firstCreds.key).to.equal("this-is-a-secret-1")
+    expect(secondCreds.email).to.equal("email_2@example.com")
+    expect(secondCreds.key).to.equal("this-is-a-secret-2")
+    expect(thirdCreds.email).to.equal("email_1@example.com")
+    expect(thirdCreds.key).to.equal("this-is-a-secret-1")
+  })
+})


### PR DESCRIPTION
This PR is a swing at #183. The code in here is rough and untested, but demonstrates how multiple GA credentials can be stored as environment variables.

I'm opening the PR early for input about whether we think this is the right direction?

##### Commit Message:

This commit adds a function that provides secret keys and report emails on rotation. This is necessary because we have to maintain several sets of DAP credentials to stay under Google's API rate limits.

This commit lets the analytics reporter call a function to get a set of creds which are provided on rotation. This means an even dispersement of creds amongst API calls.

The creds are loaded by looking for environment variables with the `ANALYTICS_KEY` and `ANALYTICS_REPORT_EMAIL` prefix and then grouping those based on suffix. So, for example, `ANALYTICS_KEY_1` and `ANALYTICS_REPORT_EMAIL_1` would be grouped together. Once the creds are grouped, they are stored in an array. When this new function is called, it returns the element that succeeds the last element it returned. At the end of the array, it goes back to the beginning.
