### PR TITLE
[HOLD] Use travis for continuous deploy

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,8 +1,18 @@
 language: node_js
 node_js:
-- "7"
-
+- '7'
 sudo: false
-
 os:
 - linux
+deploy:
+  edge: true
+  provider: cloudfoundry
+  username:
+    secure: tdG9/1XNKBhSA8Rf9qfu993l8tlPnPoVXlSG/CdZLiRsWSJK4wth2dM+/K+CH6IvrBicZgh1nR6iaoJ9PsPK3hYx1qmMmPQ+8/+hxEo+sCXF+hwDypmYStkfGQ7Ihp1aonT08aaW7UOxrqM15lQL6d3HOV2UY/24sCQFeYC5euo=
+  password:
+    secure: 2/4Cgn8Jt1OTLxJthuT/qEK8qXqCEThLqdKsuzM2S2heenDf+llNSz3WEhLUe8lMTYqg85s0hARlXn5bBgL+kR6SdITYzkb9GpsYKfntNhUZmncM5feR++AGrXl1IVGCL++qi8Lhn7hjCdtxDvcTELh/xr8UZKtXGg8YZmbRX8g=
+  api: https://api.fr.cloud.gov
+  organization: gsa-opp-analytics
+  space: analytics-dev
+  on:
+    branch: master


### PR DESCRIPTION
Hold for #193

This commit deploys from travis using the cloud foundry provider.

#193 moves all of the things the app needs to deploy into env variables, so credentials do not need to be in a developers machine. This makes it possible to deploy from CI because we won't need to save these files on the machine deploying.

After this commit, changesets merged into master will be automatically deployed to cloud.gov.