### PR TITLE
[HOLD] Add --agency option to the CLI

### DIFF
--- a/README.md
+++ b/README.md
@@ -232,6 +232,12 @@ analytics --frequency=realtime
 analytics --publish --debug
 ```
 
+* `--agency` - provide an agency name to associate with the report
+
+```bash
+analytics --agency health-human-services
+```
+
 ### Deploying to GovCloud
 
 The analytics reporter runs on :cloud:.gov. Please refer to the `manifest.yml`

--- a/deploy/daily.sh
+++ b/deploy/daily.sh
@@ -2,167 +2,167 @@
 
 # JSON and CSV versions
 source $HOME/dap-1.env
-$HOME/bin/analytics --publish --frequency=daily --slim --verbose
+$HOME/bin/analytics --publish --frequency=daily --slim --verbose --write-to-database
 $HOME/bin/analytics --publish --frequency=daily --slim --verbose --csv
 
 # Department of Education
 source $HOME/dap-1.env
 source $HOME/deploy/envs/education.env
-$HOME/bin/analytics --publish --frequency=daily --slim --verbose
+$HOME/bin/analytics --publish --frequency=daily --slim --verbose --write-to-database --agency=$AGENCY_NAME
 $HOME/bin/analytics --publish --frequency=daily --slim --verbose --csv
 
 # Department of Veterans Affairs
 source $HOME/dap-1.env
 source $HOME/deploy/envs/veterans-affairs.env
-$HOME/bin/analytics --publish --frequency=daily --slim --verbose
+$HOME/bin/analytics --publish --frequency=daily --slim --verbose --write-to-database --agency=$AGENCY_NAME
 $HOME/bin/analytics --publish --frequency=daily --slim --verbose --csv
 
 # National Aeronautics and Space Administration
 source $HOME/dap-1.env
 source $HOME/deploy/envs/national-aeronautics-space-administration.env
-$HOME/bin/analytics --publish --frequency=daily --slim --verbose
+$HOME/bin/analytics --publish --frequency=daily --slim --verbose --write-to-database --agency=$AGENCY_NAME
 $HOME/bin/analytics --publish --frequency=daily --slim --verbose --csv
 
 # Department of Justice
 source $HOME/dap-1.env
 source $HOME/deploy/envs/justice.env
-$HOME/bin/analytics --publish --frequency=daily --slim --verbose
+$HOME/bin/analytics --publish --frequency=daily --slim --verbose --write-to-database --agency=$AGENCY_NAME
 $HOME/bin/analytics --publish --frequency=daily --slim --verbose --csv
 
 # Department of Commerce
 source $HOME/dap-1.env
 source $HOME/deploy/envs/commerce.env
-$HOME/bin/analytics --publish --frequency=daily --slim --verbose
+$HOME/bin/analytics --publish --frequency=daily --slim --verbose --write-to-database --agency=$AGENCY_NAME
 $HOME/bin/analytics --publish --frequency=daily --slim --verbose --csv
 
 # Environmental Protection Agency
 source $HOME/dap-1.env
 source $HOME/deploy/envs/environmental-protection-agency.env
-$HOME/bin/analytics --publish --frequency=daily --slim --verbose
+$HOME/bin/analytics --publish --frequency=daily --slim --verbose --write-to-database --agency=$AGENCY_NAME
 $HOME/bin/analytics --publish --frequency=daily --slim --verbose --csv
 
 # Small Business Administration
 source $HOME/dap-1.env
 source $HOME/deploy/envs/small-business-administration.env
-$HOME/bin/analytics --publish --frequency=daily --slim --verbose
+$HOME/bin/analytics --publish --frequency=daily --slim --verbose --write-to-database --agency=$AGENCY_NAME
 $HOME/bin/analytics --publish --frequency=daily --slim --verbose --csv
 
 # Department of Energy
 source $HOME/dap-1.env
 source $HOME/deploy/envs/energy.env
-$HOME/bin/analytics --publish --frequency=daily --slim --verbose
+$HOME/bin/analytics --publish --frequency=daily --slim --verbose --write-to-database --agency=$AGENCY_NAME
 $HOME/bin/analytics --publish --frequency=daily --slim --verbose --csv
 
 # Department of the Interior
 source $HOME/dap-1.env
 source $HOME/deploy/envs/interior.env
-$HOME/bin/analytics --publish --frequency=daily --slim --verbose
+$HOME/bin/analytics --publish --frequency=daily --slim --verbose --write-to-database --agency=$AGENCY_NAME
 $HOME/bin/analytics --publish --frequency=daily --slim --verbose --csv
 
 # National Archives and Records Administration
 source $HOME/dap-1.env
 source $HOME/deploy/envs/national-archives-records-administration.env
-$HOME/bin/analytics --publish --frequency=daily --slim --verbose
+$HOME/bin/analytics --publish --frequency=daily --slim --verbose --write-to-database --agency=$AGENCY_NAME
 $HOME/bin/analytics --publish --frequency=daily --slim --verbose --csv
 
 # Department of Agriculture
 source $HOME/dap-1.env
 source $HOME/deploy/envs/agriculture.env
-$HOME/bin/analytics --publish --frequency=daily --slim --verbose
+$HOME/bin/analytics --publish --frequency=daily --slim --verbose --write-to-database --agency=$AGENCY_NAME
 $HOME/bin/analytics --publish --frequency=daily --slim --verbose --csv
 
 # Department of Defense
 source $HOME/dap-1.env
 source $HOME/deploy/envs/defense.env
-$HOME/bin/analytics --publish --frequency=daily --slim --verbose
+$HOME/bin/analytics --publish --frequency=daily --slim --verbose --write-to-database --agency=$AGENCY_NAME
 $HOME/bin/analytics --publish --frequency=daily --slim --verbose --csv
 
 # Department of Health and Human Services
 source $HOME/dap-2.env
 source $HOME/deploy/envs/health-human-services.env
-$HOME/bin/analytics --publish --frequency=daily --slim --verbose
+$HOME/bin/analytics --publish --frequency=daily --slim --verbose --write-to-database --agency=$AGENCY_NAME
 $HOME/bin/analytics --publish --frequency=daily --slim --verbose --csv
 
 # Department of Housing and Urban Development
 source $HOME/dap-2.env
 source $HOME/deploy/envs/housing-urban-development.env
-$HOME/bin/analytics --publish --frequency=daily --slim --verbose
+$HOME/bin/analytics --publish --frequency=daily --slim --verbose --write-to-database --agency=$AGENCY_NAME
 $HOME/bin/analytics --publish --frequency=daily --slim --verbose --csv
 
 # Department of Homeland Security
 source $HOME/dap-2.env
 source $HOME/deploy/envs/homeland-security.env
-$HOME/bin/analytics --publish --frequency=daily --slim --verbose
+$HOME/bin/analytics --publish --frequency=daily --slim --verbose --write-to-database --agency=$AGENCY_NAME
 $HOME/bin/analytics --publish --frequency=daily --slim --verbose --csv
 
 # Department of Labor
 source $HOME/dap-2.env
 source $HOME/deploy/envs/labor.env
-$HOME/bin/analytics --publish --frequency=daily --slim --verbose
+$HOME/bin/analytics --publish --frequency=daily --slim --verbose --write-to-database --agency=$AGENCY_NAME
 $HOME/bin/analytics --publish --frequency=daily --slim --verbose --csv
 
 # Department of State
 source $HOME/dap-2.env
 source $HOME/deploy/envs/state.env
-$HOME/bin/analytics --publish --frequency=daily --slim --verbose
+$HOME/bin/analytics --publish --frequency=daily --slim --verbose --write-to-database --agency=$AGENCY_NAME
 $HOME/bin/analytics --publish --frequency=daily --slim --verbose --csv
 
 # Department of Transportation
 source $HOME/dap-2.env
 source $HOME/deploy/envs/transportation.env
-$HOME/bin/analytics --publish --frequency=daily --slim --verbose
+$HOME/bin/analytics --publish --frequency=daily --slim --verbose --write-to-database --agency=$AGENCY_NAME
 $HOME/bin/analytics --publish --frequency=daily --slim --verbose --csv
 
 # Department of the Treasury
 source $HOME/dap-2.env
 source $HOME/deploy/envs/treasury.env
-$HOME/bin/analytics --publish --frequency=daily --slim --verbose
+$HOME/bin/analytics --publish --frequency=daily --slim --verbose --write-to-database --agency=$AGENCY_NAME
 $HOME/bin/analytics --publish --frequency=daily --slim --verbose --csv
 
 # Agency for International Development
 source $HOME/dap-2.env
 source $HOME/deploy/envs/agency-international-development.env
-$HOME/bin/analytics --publish --frequency=daily --slim --verbose
+$HOME/bin/analytics --publish --frequency=daily --slim --verbose --write-to-database --agency=$AGENCY_NAME
 $HOME/bin/analytics --publish --frequency=daily --slim --verbose --csv
 
 # General Services Administration
 source $HOME/dap-2.env
 source $HOME/deploy/envs/general-services-administration.env
-$HOME/bin/analytics --publish --frequency=daily --slim --verbose
+$HOME/bin/analytics --publish --frequency=daily --slim --verbose --write-to-database --agency=$AGENCY_NAME
 $HOME/bin/analytics --publish --frequency=daily --slim --verbose --csv
 
 # National Science Foundation
 source $HOME/dap-2.env
 source $HOME/deploy/envs/national-science-foundation.env
-$HOME/bin/analytics --publish --frequency=daily --slim --verbose
+$HOME/bin/analytics --publish --frequency=daily --slim --verbose --write-to-database --agency=$AGENCY_NAME
 $HOME/bin/analytics --publish --frequency=daily --slim --verbose --csv
 
 # Nuclear Regulatory Commission
 source $HOME/dap-2.env
 source $HOME/deploy/envs/nuclear-regulatory-commission.env
-$HOME/bin/analytics --publish --frequency=daily --slim --verbose
+$HOME/bin/analytics --publish --frequency=daily --slim --verbose --write-to-database --agency=$AGENCY_NAME
 $HOME/bin/analytics --publish --frequency=daily --slim --verbose --csv
 
 # Office of Personnel Management
 source $HOME/dap-2.env
 source $HOME/deploy/envs/office-personnel-management.env
-$HOME/bin/analytics --publish --frequency=daily --slim --verbose
+$HOME/bin/analytics --publish --frequency=daily --slim --verbose --write-to-database --agency=$AGENCY_NAME
 $HOME/bin/analytics --publish --frequency=daily --slim --verbose --csv
 
 # Social Security Administration
 source $HOME/dap-2.env
 source $HOME/deploy/envs/social-security-administration.env
-$HOME/bin/analytics --publish --frequency=daily --slim --verbose
+$HOME/bin/analytics --publish --frequency=daily --slim --verbose --write-to-database --agency=$AGENCY_NAME
 $HOME/bin/analytics --publish --frequency=daily --slim --verbose --csv
 
 # Postal Service
 source $HOME/dap-2.env
 source $HOME/deploy/envs/postal-service.env
-$HOME/bin/analytics --publish --frequency=daily --slim --verbose
+$HOME/bin/analytics --publish --frequency=daily --slim --verbose --write-to-database --agency=$AGENCY_NAME
 $HOME/bin/analytics --publish --frequency=daily --slim --verbose --csv
 
 # Executive Office of the President
 source $HOME/dap-2.env
 source $HOME/deploy/envs/executive-office-president.env
-$HOME/bin/analytics --publish --frequency=daily --slim --verbose
+$HOME/bin/analytics --publish --frequency=daily --slim --verbose --write-to-database --agency=$AGENCY_NAME
 $HOME/bin/analytics --publish --frequency=daily --slim --verbose --csv

--- a/deploy/envs/agency-international-development.env
+++ b/deploy/envs/agency-international-development.env
@@ -1,3 +1,4 @@
 # Agency for International Development
 export ANALYTICS_REPORT_IDS="ga:68380943"
+export AGENCY_NAME=agency-international-development
 export AWS_BUCKET_PATH=data/agency-international-development

--- a/deploy/envs/agriculture.env
+++ b/deploy/envs/agriculture.env
@@ -1,4 +1,5 @@
 # Department of Agriculture
 export ANALYTICS_REPORT_IDS="ga:65240995"
+export AGENCY_NAME=agriculture
 export AWS_BUCKET_PATH=data/agriculture
 

--- a/deploy/envs/commerce.env
+++ b/deploy/envs/commerce.env
@@ -1,4 +1,4 @@
 # Department of Commerce
 export ANALYTICS_REPORT_IDS="ga:66877186"
+export AGENCY_NAME=commerce
 export AWS_BUCKET_PATH=data/commerce
-

--- a/deploy/envs/defense.env
+++ b/deploy/envs/defense.env
@@ -1,3 +1,4 @@
 # Department of Defense
 export ANALYTICS_REPORT_IDS="ga:67120289"
+export AGENCY_NAME=defense
 export AWS_BUCKET_PATH=data/defense

--- a/deploy/envs/education.env
+++ b/deploy/envs/education.env
@@ -1,3 +1,4 @@
 # Department of Education
 export ANALYTICS_REPORT_IDS="ga:67200736"
+export AGENCY_NAME=education
 export AWS_BUCKET_PATH=data/education

--- a/deploy/envs/energy.env
+++ b/deploy/envs/energy.env
@@ -1,4 +1,5 @@
 # Department of Energy
 export ANALYTICS_REPORT_IDS="ga:69826574"
+export AGENCY_NAME=energy
 export AWS_BUCKET_PATH=data/energy
 

--- a/deploy/envs/environmental-protection-agency.env
+++ b/deploy/envs/environmental-protection-agency.env
@@ -1,4 +1,5 @@
 # Environmental Protection Agency
 export ANALYTICS_REPORT_IDS="ga:68948437"
+export AGENCY_NAME=environmental-protection-agency
 export AWS_BUCKET_PATH=data/environmental-protection-agency
 

--- a/deploy/envs/executive-office-president.env
+++ b/deploy/envs/executive-office-president.env
@@ -1,3 +1,4 @@
 # Executive Office of the President
 export ANALYTICS_REPORT_IDS="ga:66351974"
+export AGENCY_NAME=executive-office-president
 export AWS_BUCKET_PATH=data/executive-office-president

--- a/deploy/envs/general-services-administration.env
+++ b/deploy/envs/general-services-administration.env
@@ -1,3 +1,4 @@
 # General Services Administration
 export ANALYTICS_REPORT_IDS="ga:65263002"
+export AGENCY_NAME=general-services-administration
 export AWS_BUCKET_PATH=data/general-services-administration

--- a/deploy/envs/health-human-services.env
+++ b/deploy/envs/health-human-services.env
@@ -1,4 +1,5 @@
 # Department of Health and Human Services
 export ANALYTICS_REPORT_IDS="ga:72643802"
+export AGENCY_NAME=health-human-services
 export AWS_BUCKET_PATH=data/health-human-services
 

--- a/deploy/envs/homeland-security.env
+++ b/deploy/envs/homeland-security.env
@@ -1,4 +1,5 @@
 # Department of Homeland Security
 export ANALYTICS_REPORT_IDS="ga:67460690"
+export AGENCY_NAME=homeland-security
 export AWS_BUCKET_PATH=data/homeland-security
 

--- a/deploy/envs/housing-urban-development.env
+++ b/deploy/envs/housing-urban-development.env
@@ -1,4 +1,4 @@
 # Department of Housing and Urban Development
 export ANALYTICS_REPORT_IDS="ga:69364976"
+export AGENCY_NAME=housing-urban-development
 export AWS_BUCKET_PATH=data/housing-urban-development
-

--- a/deploy/envs/interior.env
+++ b/deploy/envs/interior.env
@@ -1,4 +1,4 @@
 # Department of the Interior
 export ANALYTICS_REPORT_IDS="ga:65366693"
+export AGENCY_NAME=interior
 export AWS_BUCKET_PATH=data/interior
-

--- a/deploy/envs/justice.env
+++ b/deploy/envs/justice.env
@@ -1,4 +1,4 @@
 # Department of Justice
 export ANALYTICS_REPORT_IDS="ga:65501425"
+export AGENCY_NAME=justice
 export AWS_BUCKET_PATH=data/justice
-

--- a/deploy/envs/labor.env
+++ b/deploy/envs/labor.env
@@ -1,4 +1,4 @@
 # Department of Labor
 export ANALYTICS_REPORT_IDS="ga:66158666"
+export AGENCY_NAME=labor
 export AWS_BUCKET_PATH=data/labor
-

--- a/deploy/envs/national-aeronautics-space-administration.env
+++ b/deploy/envs/national-aeronautics-space-administration.env
@@ -1,4 +1,4 @@
 # National Aeronautics and Space Administration
 export ANALYTICS_REPORT_IDS="ga:68619810"
+export AGENCY_NAME=national-aeronautics-space-administration
 export AWS_BUCKET_PATH=data/national-aeronautics-space-administration
-

--- a/deploy/envs/national-archives-records-administration.env
+++ b/deploy/envs/national-archives-records-administration.env
@@ -1,4 +1,4 @@
 # National Archives and Records Administration
 export ANALYTICS_REPORT_IDS="ga:67886610"
+export AGENCY_NAME=national-archives-records-administration
 export AWS_BUCKET_PATH=data/national-archives-records-administration
-

--- a/deploy/envs/national-science-foundation.env
+++ b/deploy/envs/national-science-foundation.env
@@ -1,4 +1,4 @@
 # National Science Foundation
 export ANALYTICS_REPORT_IDS="ga:67850613"
+export AGENCY_NAME=national-science-foundation
 export AWS_BUCKET_PATH=data/national-science-foundation
-

--- a/deploy/envs/nuclear-regulatory-commission.env
+++ b/deploy/envs/nuclear-regulatory-commission.env
@@ -1,3 +1,4 @@
 # Nuclear Regulatory Commission
 export ANALYTICS_REPORT_IDS="ga:67691948"
+export AGENCY_NAME=nuclear-regulatory-commission
 export AWS_BUCKET_PATH=data/nuclear-regulatory-commission

--- a/deploy/envs/office-personnel-management.env
+++ b/deploy/envs/office-personnel-management.env
@@ -1,3 +1,4 @@
 # Office of Personnel Management
 export ANALYTICS_REPORT_IDS="ga:68758375"
+export AGENCY_NAME=office-personnel-management
 export AWS_BUCKET_PATH=data/office-personnel-management

--- a/deploy/envs/postal-service.env
+++ b/deploy/envs/postal-service.env
@@ -1,3 +1,4 @@
 # Postal Service
 export ANALYTICS_REPORT_IDS="ga:100911348"
+export AGENCY_NAME=postal-service
 export AWS_BUCKET_PATH=data/postal-service

--- a/deploy/envs/small-business-administration.env
+++ b/deploy/envs/small-business-administration.env
@@ -1,4 +1,4 @@
 # Small Business Administration
 export ANALYTICS_REPORT_IDS="ga:68909496"
+export AGENCY_NAME=small-business-administration
 export AWS_BUCKET_PATH=data/small-business-administration
-

--- a/deploy/envs/social-security-administration.env
+++ b/deploy/envs/social-security-administration.env
@@ -1,3 +1,4 @@
 # Social Security Administration
 export ANALYTICS_REPORT_IDS="ga:68055007"
+export AGENCY_NAME=social-security-administration
 export AWS_BUCKET_PATH=data/social-security-administration

--- a/deploy/envs/state.env
+++ b/deploy/envs/state.env
@@ -1,3 +1,4 @@
 # Department of Transportation
 export ANALYTICS_REPORT_IDS="ga:67454734"
+export AGENCY_NAME=state
 export AWS_BUCKET_PATH=data/state

--- a/deploy/envs/transportation.env
+++ b/deploy/envs/transportation.env
@@ -1,4 +1,4 @@
 # Department of Transportation
 export ANALYTICS_REPORT_IDS="ga:66902419"
+export AGENCY_NAME=transportation
 export AWS_BUCKET_PATH=data/transportation
-

--- a/deploy/envs/treasury.env
+++ b/deploy/envs/treasury.env
@@ -1,3 +1,4 @@
 # Department of the Treasury
 export ANALYTICS_REPORT_IDS="ga:67705218"
+export AGENCY_NAME=treasury
 export AWS_BUCKET_PATH=data/treasury

--- a/deploy/envs/veterans-affairs.env
+++ b/deploy/envs/veterans-affairs.env
@@ -1,4 +1,4 @@
 # Department of Veterans Affairs
 export ANALYTICS_REPORT_IDS="ga:68076838"
+export AGENCY_NAME=veterans-affairs
 export AWS_BUCKET_PATH=data/veterans-affairs
-

--- a/deploy/hourly.sh
+++ b/deploy/hourly.sh
@@ -5,139 +5,139 @@ source $HOME/.bashrc
 
 # just the one awkward 'today' report
 source $HOME/dap-1.env
-$HOME/bin/analytics --publish --frequency=hourly --slim --verbose
+$HOME/bin/analytics --publish --frequency=hourly --slim --verbose --write-to-database
 
 # Department of Education
 source $HOME/dap-1.env
 source $HOME/deploy/envs/education.env
-$HOME/bin/analytics --publish --frequency=hourly --slim --verbose
+$HOME/bin/analytics --publish --frequency=hourly --slim --verbose --write-to-database --agency=$AGENCY_NAME
 
 # National Aeronautics and Space Administration
 source $HOME/dap-1.env
 source $HOME/deploy/envs/national-aeronautics-space-administration.env
-$HOME/bin/analytics --publish --frequency=hourly --slim --verbose
+$HOME/bin/analytics --publish --frequency=hourly --slim --verbose --write-to-database --agency=$AGENCY_NAME
 
 # Department of Justice
 source $HOME/dap-1.env
 source $HOME/deploy/envs/justice.env
-$HOME/bin/analytics --publish --frequency=hourly --slim --verbose
+$HOME/bin/analytics --publish --frequency=hourly --slim --verbose --write-to-database --agency=$AGENCY_NAME
 
 # Department of Veterans Affairs
 source $HOME/dap-1.env
 source $HOME/deploy/envs/veterans-affairs.env
-$HOME/bin/analytics --publish --frequency=hourly --slim --verbose
+$HOME/bin/analytics --publish --frequency=hourly --slim --verbose --write-to-database --agency=$AGENCY_NAME
 
 # Department of Commerce
 source $HOME/dap-1.env
 source $HOME/deploy/envs/commerce.env
-$HOME/bin/analytics --publish --frequency=hourly --slim --verbose
+$HOME/bin/analytics --publish --frequency=hourly --slim --verbose --write-to-database --agency=$AGENCY_NAME
 
 # Environmental Protection Agency
 source $HOME/dap-1.env
 source $HOME/deploy/envs/environmental-protection-agency.env
-$HOME/bin/analytics --publish --frequency=hourly --slim --verbose
+$HOME/bin/analytics --publish --frequency=hourly --slim --verbose --write-to-database --agency=$AGENCY_NAME
 
 # Small Business Administration
 source $HOME/dap-1.env
 source $HOME/deploy/envs/small-business-administration.env
-$HOME/bin/analytics --publish --frequency=hourly --slim --verbose
+$HOME/bin/analytics --publish --frequency=hourly --slim --verbose --write-to-database --agency=$AGENCY_NAME
 
 # Department of Energy
 source $HOME/dap-1.env
 source $HOME/deploy/envs/energy.env
-$HOME/bin/analytics --publish --frequency=hourly --slim --verbose
+$HOME/bin/analytics --publish --frequency=hourly --slim --verbose --write-to-database --agency=$AGENCY_NAME
 
 # Department of the Interior
 source $HOME/dap-1.env
 source $HOME/deploy/envs/interior.env
-$HOME/bin/analytics --publish --frequency=hourly --slim --verbose
+$HOME/bin/analytics --publish --frequency=hourly --slim --verbose --write-to-database --agency=$AGENCY_NAME
 
 # National Archives and Records Administration
 source $HOME/dap-1.env
 source $HOME/deploy/envs/national-archives-records-administration.env
-$HOME/bin/analytics --publish --frequency=hourly --slim --verbose
+$HOME/bin/analytics --publish --frequency=hourly --slim --verbose --write-to-database --agency=$AGENCY_NAME
 
 # Department of Agriculture
 source $HOME/dap-1.env
 source $HOME/deploy/envs/agriculture.env
-$HOME/bin/analytics --publish --frequency=hourly --slim --verbose
+$HOME/bin/analytics --publish --frequency=hourly --slim --verbose --write-to-database --agency=$AGENCY_NAME
 
 # Department of Defense
 source $HOME/dap-1.env
 source $HOME/deploy/envs/defense.env
-$HOME/bin/analytics --publish --frequency=hourly --slim --verbose
+$HOME/bin/analytics --publish --frequency=hourly --slim --verbose --write-to-database --agency=$AGENCY_NAME
 
 # Department of Health and Human Services
 source $HOME/dap-2.env
 source $HOME/deploy/envs/health-human-services.env
-$HOME/bin/analytics --publish --frequency=hourly --slim --verbose
+$HOME/bin/analytics --publish --frequency=hourly --slim --verbose --write-to-database --agency=$AGENCY_NAME
 
 # Department of Housing and Urban Development
 source $HOME/dap-2.env
 source $HOME/deploy/envs/housing-urban-development.env
-$HOME/bin/analytics --publish --frequency=hourly --slim --verbose
+$HOME/bin/analytics --publish --frequency=hourly --slim --verbose --write-to-database --agency=$AGENCY_NAME
 
 # Department of Homeland Security
 source $HOME/dap-2.env
 source $HOME/deploy/envs/homeland-security.env
-$HOME/bin/analytics --publish --frequency=hourly --slim --verbose
+$HOME/bin/analytics --publish --frequency=hourly --slim --verbose --write-to-database --agency=$AGENCY_NAME
 
 # Department of Labor
 source $HOME/dap-2.env
 source $HOME/deploy/envs/labor.env
-$HOME/bin/analytics --publish --frequency=hourly --slim --verbose
+$HOME/bin/analytics --publish --frequency=hourly --slim --verbose --write-to-database --agency=$AGENCY_NAME
 
 # Department of State
 source $HOME/dap-2.env
 source $HOME/deploy/envs/state.env
-$HOME/bin/analytics --publish --frequency=hourly --slim --verbose
+$HOME/bin/analytics --publish --frequency=hourly --slim --verbose --write-to-database --agency=$AGENCY_NAME
 
 # Department of Transportation
 source $HOME/dap-2.env
 source $HOME/deploy/envs/transportation.env
-$HOME/bin/analytics --publish --frequency=hourly --slim --verbose
+$HOME/bin/analytics --publish --frequency=hourly --slim --verbose --write-to-database --agency=$AGENCY_NAME
 
 # Department of the Treasury
 source $HOME/dap-2.env
 source $HOME/deploy/envs/treasury.env
-$HOME/bin/analytics --publish --frequency=hourly --slim --verbose
+$HOME/bin/analytics --publish --frequency=hourly --slim --verbose --write-to-database --agency=$AGENCY_NAME
 
 # Agency for International Development
 source $HOME/dap-2.env
 source $HOME/deploy/envs/agency-international-development.env
-$HOME/bin/analytics --publish --frequency=hourly --slim --verbose
+$HOME/bin/analytics --publish --frequency=hourly --slim --verbose --write-to-database --agency=$AGENCY_NAME
 
 # General Services Administration
 source $HOME/dap-2.env
 source $HOME/deploy/envs/general-services-administration.env
-$HOME/bin/analytics --publish --frequency=hourly --slim --verbose
+$HOME/bin/analytics --publish --frequency=hourly --slim --verbose --write-to-database --agency=$AGENCY_NAME
 
 # National Science Foundation
 source $HOME/dap-2.env
 source $HOME/deploy/envs/national-science-foundation.env
-$HOME/bin/analytics --publish --frequency=hourly --slim --verbose
+$HOME/bin/analytics --publish --frequency=hourly --slim --verbose --write-to-database --agency=$AGENCY_NAME
 
 # Nuclear Regulatory Commission
 source $HOME/dap-2.env
 source $HOME/deploy/envs/nuclear-regulatory-commission.env
-$HOME/bin/analytics --publish --frequency=hourly --slim --verbose
+$HOME/bin/analytics --publish --frequency=hourly --slim --verbose --write-to-database --agency=$AGENCY_NAME
 
 # Office of Personnel Management
 source $HOME/dap-2.env
 source $HOME/deploy/envs/office-personnel-management.env
-$HOME/bin/analytics --publish --frequency=hourly --slim --verbose
+$HOME/bin/analytics --publish --frequency=hourly --slim --verbose --write-to-database --agency=$AGENCY_NAME
 
 # Social Security Administration
 source $HOME/dap-2.env
 source $HOME/deploy/envs/social-security-administration.env
-$HOME/bin/analytics --publish --frequency=hourly --slim --verbose
+$HOME/bin/analytics --publish --frequency=hourly --slim --verbose --write-to-database --agency=$AGENCY_NAME
 
 # Postal Service
 source $HOME/dap-2.env
 source $HOME/deploy/envs/postal-service.env
-$HOME/bin/analytics --publish --frequency=hourly --slim --verbose
+$HOME/bin/analytics --publish --frequency=hourly --slim --verbose --write-to-database --agency=$AGENCY_NAME
 
 # Executive Office of the President
 source $HOME/dap-2.env
 source $HOME/deploy/envs/executive-office-president.env
-$HOME/bin/analytics --publish --frequency=hourly --slim --verbose
+$HOME/bin/analytics --publish --frequency=hourly --slim --verbose --write-to-database --agency=$AGENCY_NAME

--- a/deploy/realtime.sh
+++ b/deploy/realtime.sh
@@ -4,168 +4,168 @@ export PATH=$PATH:/usr/local/bin
 source $HOME/.bashrc
 
 source $HOME/dap-1.env
-$HOME/bin/analytics --publish --frequency=realtime --slim --verbose
+$HOME/bin/analytics --publish --frequency=realtime --slim --verbose --write-to-database
 # we want just one realtime report in CSV, hardcoded for now to save on API requests
 $HOME/bin/analytics --publish --only=all-pages-realtime --slim --verbose --csv
 
 # Department of Education
 source $HOME/dap-1.env
 source $HOME/deploy/envs/education.env
-$HOME/bin/analytics --publish --frequency=realtime --slim --verbose
+$HOME/bin/analytics --publish --frequency=realtime --slim --verbose --write-to-database --agency=$AGENCY_NAME
 $HOME/bin/analytics --publish --only=all-pages-realtime --slim --verbose --csv
 
 # Department of Veterans Affairs
 source $HOME/dap-1.env
 source $HOME/deploy/envs/veterans-affairs.env
-$HOME/bin/analytics --publish --frequency=realtime --slim --verbose
+$HOME/bin/analytics --publish --frequency=realtime --slim --verbose --write-to-database --agency=$AGENCY_NAME
 $HOME/bin/analytics --publish --only=all-pages-realtime --slim --verbose --csv
 
 # National Aeronautics and Space Administration
 source $HOME/dap-1.env
 source $HOME/deploy/envs/national-aeronautics-space-administration.env
-$HOME/bin/analytics --publish --frequency=realtime --slim --verbose
+$HOME/bin/analytics --publish --frequency=realtime --slim --verbose --write-to-database --agency=$AGENCY_NAME
 $HOME/bin/analytics --publish --only=all-pages-realtime --slim --verbose --csv
 
 # Department of Justice
 source $HOME/dap-1.env
 source $HOME/deploy/envs/justice.env
-$HOME/bin/analytics --publish --frequency=realtime --slim --verbose
+$HOME/bin/analytics --publish --frequency=realtime --slim --verbose --write-to-database --agency=$AGENCY_NAME
 $HOME/bin/analytics --publish --only=all-pages-realtime --slim --verbose --csv
 
 # Department of Commerce
 source $HOME/dap-1.env
 source $HOME/deploy/envs/commerce.env
-$HOME/bin/analytics --publish --frequency=realtime --slim --verbose
+$HOME/bin/analytics --publish --frequency=realtime --slim --verbose --write-to-database --agency=$AGENCY_NAME
 $HOME/bin/analytics --publish --only=all-pages-realtime --slim --verbose --csv
 
 # Environmental Protection Agency
 source $HOME/dap-1.env
 source $HOME/deploy/envs/environmental-protection-agency.env
-$HOME/bin/analytics --publish --frequency=realtime --slim --verbose
+$HOME/bin/analytics --publish --frequency=realtime --slim --verbose --write-to-database --agency=$AGENCY_NAME
 $HOME/bin/analytics --publish --only=all-pages-realtime --slim --verbose --csv
 
 # Small Business Administration
 source $HOME/dap-1.env
 source $HOME/deploy/envs/small-business-administration.env
-$HOME/bin/analytics --publish --frequency=realtime --slim --verbose
+$HOME/bin/analytics --publish --frequency=realtime --slim --verbose --write-to-database --agency=$AGENCY_NAME
 $HOME/bin/analytics --publish --only=all-pages-realtime --slim --verbose --csv
 
 # Department of Energy
 source $HOME/dap-1.env
 source $HOME/deploy/envs/energy.env
-$HOME/bin/analytics --publish --frequency=realtime --slim --verbose
+$HOME/bin/analytics --publish --frequency=realtime --slim --verbose --write-to-database --agency=$AGENCY_NAME
 $HOME/bin/analytics --publish --only=all-pages-realtime --slim --verbose --csv
 
 # Department of the Interior
 source $HOME/dap-1.env
 source $HOME/deploy/envs/interior.env
-$HOME/bin/analytics --publish --frequency=realtime --slim --verbose
+$HOME/bin/analytics --publish --frequency=realtime --slim --verbose --write-to-database --agency=$AGENCY_NAME
 $HOME/bin/analytics --publish --only=all-pages-realtime --slim --verbose --csv
 
 # National Archives and Records Administration
 source $HOME/dap-1.env
 source $HOME/deploy/envs/national-archives-records-administration.env
-$HOME/bin/analytics --publish --frequency=realtime --slim --verbose
+$HOME/bin/analytics --publish --frequency=realtime --slim --verbose --write-to-database --agency=$AGENCY_NAME
 $HOME/bin/analytics --publish --only=all-pages-realtime --slim --verbose --csv
 
 # Department of Agriculture
 source $HOME/dap-1.env
 source $HOME/deploy/envs/agriculture.env
-$HOME/bin/analytics --publish --frequency=realtime --slim --verbose
+$HOME/bin/analytics --publish --frequency=realtime --slim --verbose --write-to-database --agency=$AGENCY_NAME
 $HOME/bin/analytics --publish --only=all-pages-realtime --slim --verbose --csv
 
 # Department of Defense
 source $HOME/dap-1.env
 source $HOME/deploy/envs/defense.env
-$HOME/bin/analytics --publish --frequency=realtime --slim --verbose
+$HOME/bin/analytics --publish --frequency=realtime --slim --verbose --write-to-database --agency=$AGENCY_NAME
 $HOME/bin/analytics --publish --only=all-pages-realtime --slim --verbose --csv
 
 # Department of Health and Human Services
 source $HOME/dap-2.env
 source $HOME/deploy/envs/health-human-services.env
-$HOME/bin/analytics --publish --frequency=realtime --slim --verbose
+$HOME/bin/analytics --publish --frequency=realtime --slim --verbose --write-to-database --agency=$AGENCY_NAME
 $HOME/bin/analytics --publish --only=all-pages-realtime --slim --verbose --csv
 
 # Department of Housing and Urban Development
 source $HOME/dap-2.env
 source $HOME/deploy/envs/housing-urban-development.env
-$HOME/bin/analytics --publish --frequency=realtime --slim --verbose
+$HOME/bin/analytics --publish --frequency=realtime --slim --verbose --write-to-database --agency=$AGENCY_NAME
 $HOME/bin/analytics --publish --only=all-pages-realtime --slim --verbose --csv
 
 # Department of Homeland Security
 source $HOME/dap-2.env
 source $HOME/deploy/envs/homeland-security.env
-$HOME/bin/analytics --publish --frequency=realtime --slim --verbose
+$HOME/bin/analytics --publish --frequency=realtime --slim --verbose --write-to-database --agency=$AGENCY_NAME
 $HOME/bin/analytics --publish --only=all-pages-realtime --slim --verbose --csv
 
 # Department of Labor
 source $HOME/dap-2.env
 source $HOME/deploy/envs/labor.env
-$HOME/bin/analytics --publish --frequency=realtime --slim --verbose
+$HOME/bin/analytics --publish --frequency=realtime --slim --verbose --write-to-database --agency=$AGENCY_NAME
 $HOME/bin/analytics --publish --only=all-pages-realtime --slim --verbose --csv
 
 # Department of State
 source $HOME/dap-2.env
 source $HOME/deploy/envs/state.env
-$HOME/bin/analytics --publish --frequency=realtime --slim --verbose
+$HOME/bin/analytics --publish --frequency=realtime --slim --verbose --write-to-database --agency=$AGENCY_NAME
 $HOME/bin/analytics --publish --only=all-pages-realtime --slim --verbose --csv
 
 # Department of Transportation
 source $HOME/dap-2.env
 source $HOME/deploy/envs/transportation.env
-$HOME/bin/analytics --publish --frequency=realtime --slim --verbose
+$HOME/bin/analytics --publish --frequency=realtime --slim --verbose --write-to-database --agency=$AGENCY_NAME
 $HOME/bin/analytics --publish --only=all-pages-realtime --slim --verbose --csv
 
 # Department of the Treasury
 source $HOME/dap-2.env
 source $HOME/deploy/envs/treasury.env
-$HOME/bin/analytics --publish --frequency=realtime --slim --verbose
+$HOME/bin/analytics --publish --frequency=realtime --slim --verbose --write-to-database --agency=$AGENCY_NAME
 $HOME/bin/analytics --publish --only=all-pages-realtime --slim --verbose --csv
 
 # Agency for International Development
 source $HOME/dap-2.env
 source $HOME/deploy/envs/agency-international-development.env
-$HOME/bin/analytics --publish --frequency=realtime --slim --verbose
+$HOME/bin/analytics --publish --frequency=realtime --slim --verbose --write-to-database --agency=$AGENCY_NAME
 $HOME/bin/analytics --publish --only=all-pages-realtime --slim --verbose --csv
 
 # General Services Administration
 source $HOME/dap-2.env
 source $HOME/deploy/envs/general-services-administration.env
-$HOME/bin/analytics --publish --frequency=realtime --slim --verbose
+$HOME/bin/analytics --publish --frequency=realtime --slim --verbose --write-to-database --agency=$AGENCY_NAME
 $HOME/bin/analytics --publish --only=all-pages-realtime --slim --verbose --csv
 
 # National Science Foundation
 source $HOME/dap-2.env
 source $HOME/deploy/envs/national-science-foundation.env
-$HOME/bin/analytics --publish --frequency=realtime --slim --verbose
+$HOME/bin/analytics --publish --frequency=realtime --slim --verbose --write-to-database --agency=$AGENCY_NAME
 $HOME/bin/analytics --publish --only=all-pages-realtime --slim --verbose --csv
 
 # Nuclear Regulatory Commission
 source $HOME/dap-2.env
 source $HOME/deploy/envs/nuclear-regulatory-commission.env
-$HOME/bin/analytics --publish --frequency=realtime --slim --verbose
+$HOME/bin/analytics --publish --frequency=realtime --slim --verbose --write-to-database --agency=$AGENCY_NAME
 $HOME/bin/analytics --publish --only=all-pages-realtime --slim --verbose --csv
 
 # Office of Personnel Management
 source $HOME/dap-2.env
 source $HOME/deploy/envs/office-personnel-management.env
-$HOME/bin/analytics --publish --frequency=realtime --slim --verbose
+$HOME/bin/analytics --publish --frequency=realtime --slim --verbose --write-to-database --agency=$AGENCY_NAME
 $HOME/bin/analytics --publish --only=all-pages-realtime --slim --verbose --csv
 
 # Social Security Administration
 source $HOME/dap-2.env
 source $HOME/deploy/envs/social-security-administration.env
-$HOME/bin/analytics --publish --frequency=realtime --slim --verbose
+$HOME/bin/analytics --publish --frequency=realtime --slim --verbose --write-to-database --agency=$AGENCY_NAME
 $HOME/bin/analytics --publish --only=all-pages-realtime --slim --verbose --csv
 
 # Postal Service
 source $HOME/dap-2.env
 source $HOME/deploy/envs/postal-service.env
-$HOME/bin/analytics --publish --frequency=realtime --slim --verbose
+$HOME/bin/analytics --publish --frequency=realtime --slim --verbose --write-to-database --agency=$AGENCY_NAME
 $HOME/bin/analytics --publish --only=all-pages-realtime --slim --verbose --csv
 
 # Executive Office of the President
 source $HOME/dap-2.env
 source $HOME/deploy/envs/executive-office-president.env
-$HOME/bin/analytics --publish --frequency=realtime --slim --verbose
+$HOME/bin/analytics --publish --frequency=realtime --slim --verbose --write-to-database --agency=$AGENCY_NAME
 $HOME/bin/analytics --publish --only=all-pages-realtime --slim --verbose --csv

--- a/index.js
+++ b/index.js
@@ -64,6 +64,8 @@ var run = function(options) {
 
         if (options.debug) console.log("[" + report.name + "] Saving report data...");
 
+        if (options.agency) data.agnecy = options.agency;
+
         // CSV, see https://github.com/C2FO/fast-csv#formatting-functions
         if (options.csv) {
           csv.writeToString(data['data'], {headers: true}, function(err, data) {


### PR DESCRIPTION
This command adds an option for specifying an agency in the CLI options. This allows the name of the agency the data is being pulled for to be included in the final report, and in the data that is written to the database.

Ref #194

Hold for #197