### PR TITLE
Do not overwrite the domain if it's already present

### DIFF
--- a/src/process-ga-data.js
+++ b/src/process-ga-data.js
@@ -83,7 +83,7 @@ const _processRow = ({ row, data, report }) => {
     point[field] = value
   })
 
-  if (config.account.hostname) {
+  if (config.account.hostname && !('domain' in point)) {
     point.domain = config.account.hostname
   }
 

--- a/test/fixtures/data_with_hostname.js
+++ b/test/fixtures/data_with_hostname.js
@@ -1,0 +1,31 @@
+module.exports = {
+  kind: 'analytics#gaData',
+  id: 'https://www.googleapis.com/analytics/v3/data/ga?ids=ga:96302018&dimensions=ga:date,ga:hour&metrics=ga:sessions&start-date=today&end-date=today&max-results=10000',
+  query: {
+    'start-date': 'today', 'end-date': 'today', ids: 'ga:96302018',
+    dimensions: 'ga:date,ga:hour', metrics: [ 'ga:sessions' ],
+    'start-index': 1, 'max-results': 10000, samplingLevel: 'HIGHER_PRECISION',
+  },
+  itemsPerPage: 10000,
+  totalResults: 24,
+  selfLink: 'https://www.googleapis.com/analytics/v3/data/ga?ids=ga:96302018&dimensions=ga:date,ga:hour&metrics=ga:sessions&start-date=today&end-date=today&max-results=10000',
+  profileInfo: {
+    profileId: '96302018',
+    accountId: '33523145',
+    webPropertyId: 'UA-33523145-1',
+    internalWebPropertyId: '60822123',
+    profileName: 'Z3. Adjusted Gov-Wide Reporting Profile (.gov & .mil only)',
+    tableId: 'ga:96302018'
+  },
+  containsSampledData: false,
+  columnHeaders: [
+    { name: 'ga:date', columnType: 'DIMENSION', dataType: 'STRING' },
+    { name: 'ga:hour', columnType: 'DIMENSION', dataType: 'STRING' },
+    { name: 'ga:hostname', columnType: 'DIMENSION', dataType: 'STRING' },
+    { name: 'ga:sessions', columnType: 'METRIC', dataType: 'INTEGER' }
+  ],
+  totalsForAllResults: { 'ga:sessions': '6782212' },
+  rows: Array(24).fill(100).map((val, index) => {
+    return ["20170130", `${index}`.length < 2 ? `0${index}` : `${index}`, `www.example${index}.com`,`${val}`]
+  }),
+}

--- a/test/process-ga-data.test.js
+++ b/test/process-ga-data.test.js
@@ -2,6 +2,7 @@ const expect = require("chai").expect
 const proxyquire = require("proxyquire")
 const reportFixture = require("./fixtures/report")
 const dataFixture = require("./fixtures/data")
+const dataWithHostnameFixture = require("./fixtures/data_with_hostname")
 
 proxyquire.noCallThru()
 
@@ -92,6 +93,16 @@ describe("processGoogleAnalyticsData(report, data)", () => {
 
     const result = processGoogleAnalyticsData(report, data)
     expect(result.data[0].domain).to.equal("www.example.gov")
+  })
+
+  it("should not overwrite the domain with a hostname from the config", () => {
+    let dataWithHostname
+    dataWithHostname = Object.assign({}, dataWithHostnameFixture)
+    report.realtime = true
+    config.account.hostname = "www.example.gov"
+
+    const result = processGoogleAnalyticsData(report, dataWithHostname)
+    expect(result.data[0].domain).to.equal("www.example0.com")
   })
 
   it("should set use calculateTotals to calculate the totals", () => {


### PR DESCRIPTION
Currently, if **ANALYTICS_HOSTNAME** is set and the website is hosted on multiple domains, actual domain names are being replaced with the **ANALYTICS_HOSTNAME** value.

E.g. if **ANALYTICS_HOSTNAME**  is set to _example.com_ then **top-domains-7-days** report returns a JSON similar to this:

```javascript
{
  "name": "top-domains-7-days",
  "query": {
    "start-date": "7daysAgo",
    "end-date": "yesterday",
    "dimensions": "ga:hostname",
    "metrics": [
      "ga:sessions"
    ],
    "sort": [
      "-ga:sessions"
    ],
    "start-index": 1,
    "max-results": 20,
    "samplingLevel": "HIGHER_PRECISION"
  },
  "meta": {
    "name": "Top Domains (7 Days)",
    "description": "Last week's top 20 domains, measured by visits, for all sites."
  },
  "data": [
    {
      "domain": "example.com",
      "visits": "1"
    },
    {
      "domain": "example.com",
      "visits": "1"
    },
    {
      "domain": "example.com",
      "visits": "1"
    },
    {
      "domain": "example.com",
      "visits": "1"
    },
    {
      "domain": "example.com",
      "visits": "1"
    },
    {
      "domain": "example.com",
      "visits": "1"
    },
    {
      "domain": "example.com",
      "visits": "1"
    }
  ],
  "totals": {
    "visits": 7
  },
  "taken_at": "2017-02-23T21:29:25.215Z"
}
```