### PR TITLE
Consolidate GA logic into GoogleAnalyticsClient

### DIFF
--- a/src/analytics.js
+++ b/src/analytics.js
@@ -5,8 +5,6 @@ const config = require('./config');
 
 const GoogleAnalyticsClient = require("./google-analytics/client")
 const GoogleAnalyticsDataProcessor = require("./process-results/ga-data-processor")
-const GoogleAnalyticsQueryAuthorizer = require("./google-analytics/query-authorizer")
-const GoogleAnalyticsQueryBuilder = require("./google-analytics/query-builder")
 
 // The reports we want to run.
 var reports_path = config.reports_file || (path.join(process.cwd(), "reports/reports.json"));
@@ -26,10 +24,7 @@ var Analytics = {
             return callback()
         }
 
-        const query = GoogleAnalyticsQueryBuilder.buildQuery(report)
-        return GoogleAnalyticsQueryAuthorizer.authorizeQuery(query).then(query => {
-            return GoogleAnalyticsClient.fetchData(query, { realtime: report.realtime })
-        }).then(data => {
+        return GoogleAnalyticsClient.fetchData(report).then(data => {
             const processedData = GoogleAnalyticsDataProcessor.processData(report, data)
             callback(null, processedData)
         }).catch(callback)

--- a/src/google-analytics/client.js
+++ b/src/google-analytics/client.js
@@ -1,8 +1,17 @@
 const google = require("googleapis")
+const GoogleAnalyticsQueryAuthorizer = require("./query-authorizer")
+const GoogleAnalyticsQueryBuilder = require("./query-builder")
 
-const fetchData = (query, { realtime } = {}) => {
+const fetchData = (report) => {
+  const query = GoogleAnalyticsQueryBuilder.buildQuery(report)
+  return GoogleAnalyticsQueryAuthorizer.authorizeQuery(query).then(query => {
+    return _executeFetchDataRequest(query, { realtime: report.realtime })
+  })
+}
+
+const _executeFetchDataRequest = (query, { realtime }) => {
   return new Promise((resolve, reject) => {
-    get(realtime)(query, (err, data) => {
+    _get(realtime)(query, (err, data) => {
       if (err) {
         reject(err)
       } else {
@@ -12,7 +21,7 @@ const fetchData = (query, { realtime } = {}) => {
   })
 }
 
-const get = (realtime) => {
+const _get = (realtime) => {
   const analytics = google.analytics("v3")
   if (realtime) {
     return analytics.data.realtime.get

--- a/test/google-analytics/client.test.js
+++ b/test/google-analytics/client.test.js
@@ -4,63 +4,107 @@ const googleAPIsMock = require("../support/mocks/googleapis-analytics")
 
 proxyquire.noCallThru()
 
-const googleapis = {}
+let googleapis
+let GoogleAnalyticsQueryAuthorizer
+let GoogleAnalyticsQueryBuilder
+let report
 
-const GoogleAnalyticsClient = proxyquire("../../src/google-analytics/client", {
-  googleapis,
-})
+let GoogleAnalyticsClient
 
 describe("GoogleAnalyticsClient", () => {
   describe(".fetchData(query, options)", () => {
     beforeEach(() => {
-      Object.assign(googleapis, googleAPIsMock())
+      googleapis = googleAPIsMock()
+      GoogleAnalyticsQueryAuthorizer = { authorizeQuery: (query) => Promise.resolve(query) }
+      GoogleAnalyticsQueryBuilder = { buildQuery: () => ({}) }
+
+      GoogleAnalyticsClient = proxyquire("../../src/google-analytics/client", {
+        googleapis,
+        "./query-authorizer": GoogleAnalyticsQueryAuthorizer,
+        "./query-builder": GoogleAnalyticsQueryBuilder,
+      })
     })
 
-    it("should call the google api with the query", done => {
-      const query = {
-        query: "that's me"
+    it("should build and authorize a query and use that to call the google api", done => {
+      const report = { name: "realtime" }
+
+      let queryBuilderCalled = false
+      GoogleAnalyticsQueryBuilder.buildQuery = (report) => {
+        expect(report).to.deep.equal({ name: "realtime" })
+        queryBuilderCalled = true
+        return { query: true }
       }
-      googleapis.ga.get = (query, cb) => {
-        expect(query).to.deep.equal({
-          query: "that's me"
-        })
-        done()
+
+      let queryAuthorizerCalled = false
+      GoogleAnalyticsQueryAuthorizer.authorizeQuery = (query) => {
+        queryAuthorizerCalled = true
+        expect(query).to.deep.equal({ query: true })
+        query.authorized = true
+        return Promise.resolve(query)
+      }
+
+      let googleAPICalled = false
+      googleapis.ga.get = (params, cb) => {
+        googleAPICalled = true
+        expect(params).to.deep.equal({ query: true, authorized: true })
         cb(null, {})
       }
-      GoogleAnalyticsClient.fetchData(query).catch(done)
+
+      GoogleAnalyticsClient.fetchData(report).then(() => {
+        expect(queryBuilderCalled).to.be.true
+        expect(queryAuthorizerCalled).to.be.true
+        expect(googleAPICalled).to.be.true
+        done()
+      }).catch(done)
     })
 
     it("should return a promise for Google Analytics data", done => {
-      googleapis.ga.get = (query, cb) => {
+      googleapis.ga.get = (params, cb) => {
         cb(null, { data: "that's me" })
       }
-      GoogleAnalyticsClient.fetchData({}).then(data => {
-        expect(data).to.deep.equal({ data: "that's me" })
+
+      GoogleAnalyticsClient.fetchData({}).then(result => {
+        expect(result).to.deep.equal({ data: "that's me" })
         done()
       }).catch(done)
     })
 
-    it("should reject if there is a problem fetching the data", done => {
+    it("should reject if there is a problem fetching data", done => {
+      googleapis.ga.get = (params, cb) => {
+        const error = new Error("i'm an error")
+        cb(error)
+      }
+
+      GoogleAnalyticsClient.fetchData({}).catch(error => {
+        expect(error.message).to.equal("i'm an error")
+        done()
+      }).catch(done)
+    })
+
+    it("should use the data function if the report is not realtime", done => {
+      let dataFunctionCalled = false
       googleapis.ga.get = (query, cb) => {
-        cb(new Error("I'm an error"))
+        dataFunctionCalled = true
+        cb(null, {})
       }
-      GoogleAnalyticsClient.fetchData({}).catch(err => {
-        expect(err.message).to.equal("I'm an error")
+
+      GoogleAnalyticsClient.fetchData({}).then(() => {
+        expect(dataFunctionCalled).to.be.true
         done()
       }).catch(done)
     })
 
-    it("should use the data get function if options.realtime is false", done => {
-      googleapis.ga.get = () => {
-        done()
+    it("should use the realtime function if the report is not realtime", done => {
+      let realtimeFunctionCalled = false
+      googleapis.realtime.get = (query, cb) => {
+        realtimeFunctionCalled = true
+        cb(null, {})
       }
-      GoogleAnalyticsClient.fetchData({}, { realtime: false }).catch(done)
-    })
-    it("should use the realtime get function if option.realtime is true", done => {
-      googleapis.realtime.get = () => {
+
+      GoogleAnalyticsClient.fetchData({ realtime: true }).then(() => {
+        expect(realtimeFunctionCalled).to.be.true
         done()
-      }
-      GoogleAnalyticsClient.fetchData({}, { realtime: true }).catch(done)
+      }).catch(done)
     })
   })
 })


### PR DESCRIPTION
Prior to this commit, `analytics` module was calling out to the various GA related modules to build, authorize, and send queries for data. This commit takes all of the logic necessary to send a GA query and loads it into the `GoogleAnalyticsClient` module. This allows for all of the GA logic to be invoked with a simple `GoogleAnalyticsClient.fetchData(report)` call.