### PR TITLE
Export constant for analytics table name

### DIFF
--- a/src/publish/postgres.js
+++ b/src/publish/postgres.js
@@ -109,4 +109,4 @@ const _writeRegularResults = ({ db, results }) => {
   })
 }
 
-module.exports = { publish }
+module.exports = { publish, ANALYTICS_DATA_TABLE_NAME }

--- a/test/publish/postgres.test.js
+++ b/test/publish/postgres.test.js
@@ -1,4 +1,4 @@
-const ANALYTICS_DATA_TABLE_NAME = "analytics_data"
+const { ANALYTICS_DATA_TABLE_NAME } = require("../../src/publish/postgres")
 
 const expect = require("chai").expect
 const knex = require("knex")

--- a/test/support/database.js
+++ b/test/support/database.js
@@ -1,4 +1,4 @@
-const ANALYTICS_DATA_TABLE_NAME = "analytics_data"
+const { ANALYTICS_DATA_TABLE_NAME } = require("../../src/publish/postgres")
 
 const knex = require("knex")
 


### PR DESCRIPTION
This commit goes back to a comment on #197 by @konklone where it was suggested that we export the name of the analytics data table from what is now the PostgresPublisher. This commit makes that change.