### PR TITLE
Add result formatter

### DIFF
--- a/src/process-results/result-formatter.js
+++ b/src/process-results/result-formatter.js
@@ -1,0 +1,37 @@
+const csv = require("fast-csv")
+
+const formatResult = (result, format, { slim = false } = {}) => {
+  result = Object.assign({}, result)
+
+  switch(format) {
+    case "json":
+      return _formatJSON(result, { slim })
+      break
+    case "csv":
+      return _formatCSV(result)
+      break
+    default:
+      return Promise.reject("Unsupported format: " + format)
+  }
+}
+
+const _formatJSON = (result, { slim }) => {
+  if (slim) {
+   delete result.data
+  }
+  return Promise.resolve(JSON.stringify(result, null, 2))
+}
+
+const _formatCSV = (result) => {
+  return new Promise((resolve, reject) => {
+    csv.writeToString(result.data, {headers: true}, (err, data) => {
+      if (err) {
+        reject(err)
+      } else {
+        resolve(data)
+      }
+    })
+  })
+}
+
+module.exports = { formatResult }

--- a/test/process-results/result-formatter.test.js
+++ b/test/process-results/result-formatter.test.js
@@ -1,0 +1,56 @@
+const csv = require("fast-csv")
+const expect = require("chai").expect
+const proxyquire = require("proxyquire")
+const reportFixture = require("../support/fixtures/report")
+const dataFixture = require("../support/fixtures/data")
+
+const GoogleAnalyticsDataProcessor = proxyquire("../../src/process-results/ga-data-processor", {
+  "../config": { account: { hostname: "" } },
+})
+const ResultFormatter = require("../../src/process-results/result-formatter")
+
+describe("ResultFormatter", () => {
+  describe("formatResult(result, format, options)", () => {
+    let report
+    let data
+
+    beforeEach(() => {
+      report = Object.assign({}, reportFixture)
+      data = Object.assign({}, dataFixture)
+    })
+
+    it("should format results into JSON if the format is 'json'", done => {
+      const result = GoogleAnalyticsDataProcessor.processData(report, data)
+
+      ResultFormatter.formatResult(result, "json").then(formattedResult => {
+        const object = JSON.parse(formattedResult)
+        expect(object).to.deep.equal(object)
+        done()
+      }).catch(done)
+    })
+
+    it("should remove the data attribute for JSON if options.slim is true", done => {
+      const result = GoogleAnalyticsDataProcessor.processData(report, data)
+
+      ResultFormatter.formatResult(result, "json", { slim: true }).then(formattedResult => {
+        const object = JSON.parse(formattedResult)
+        expect(object.data).to.be.undefined
+        done()
+      }).catch(done)
+    })
+
+    it("should format results into CSV if the format is 'csv'", done => {
+      const result = GoogleAnalyticsDataProcessor.processData(report, data)
+
+      ResultFormatter.formatResult(result, "csv", { slim: true }).then(formattedResult => {
+        csv.fromString(formattedResult, { strictColumnHandling: true }, { headers: true })
+          .on("invalid-data", (data) => {
+            done(new Error("Invalid CSV data: " + data))
+          })
+          .on("finish", () => {
+            done()
+          })
+      }).catch(done)
+    })
+  })
+})


### PR DESCRIPTION
This commit adds a `ResultFormatter` service which can be used to format the results into either JSON or CSV. This moves the concern for formatting results out of `index.js`.