### PR TITLE
index.js cleanup

### DIFF
--- a/deploy/cron.js
+++ b/deploy/cron.js
@@ -1,58 +1,62 @@
+const winston = require("winston-color")
+
 if (process.env.NEW_RELIC_APP_NAME) {
-	console.log("Starting New Relic")
+	winston.info("Starting New Relic")
 	require("newrelic")
+} else {
+	winston.warn("Skipping New Relic Activation")
 }
 
 const spawn = require("child_process").exec;
 const execSync = require("child_process").execSync;
 
 var daily_run = function() {
-	console.log("about to run daily.sh");
+	winston.info("about to run daily.sh");
 
 	var daily = spawn("./deploy/daily.sh")
 	daily.stdout.on("data", (data) => {
-		console.log("[daily.sh] " + data)
+		winston.info("[daily.sh]", data)
 	})
 	daily.stderr.on("data", (data) => {
-		console.error("[daily.sh] " + data)
+		winston.info("[daily.sh]", data)
 	})
 	daily.on("exit", (code) => {
-		console.log("daily.sh exitted with code: " + code)
+		winston.info("daily.sh exitted with code:", code)
 	})
 }
 
 var hourly_run = function(){
-	console.log("about to run hourly.sh");
+	winston.info("about to run hourly.sh");
 
 	var hourly = spawn("./deploy/hourly.sh")
 	hourly.stdout.on("data", (data) => {
-		console.log("[hourly.sh] " + data)
+		winston.info("[hourly.sh]", data)
 	})
 	hourly.stderr.on("data", (data) => {
-		console.error("[hourly.sh] " + data)
+		winston.info("[hourly.sh]", data)
 	})
 	hourly.on("exit", (code) => {
-		console.log("hourly.sh exitted with code: " + code)
+		winston.info("hourly.sh exitted with code:", code)
 	})
 }
 
 var realtime_run = function(){
-	console.log("about to run realtime.sh");
+	winston.info("about to run realtime.sh");
 
 	var realtime = spawn("./deploy/realtime.sh")
 	realtime.stdout.on("data", (data) => {
-		console.log("[realtime.sh] " + data)
+		winston.info("[realtime.sh]", data)
 	})
 	realtime.stderr.on("data", (data) => {
-		console.error("[realtime.sh] " + data)
+		winston.info("[realtime.sh]", data)
 	})
 	realtime.on("exit", (code) => {
-		console.log("realtime.sh exitted with code: " + code)
+		winston.info("realtime.sh exitted with code:", code)
 	})
 }
 
 
-console.log("starting cron.js!");
+winston.info("starting cron.js!");
 daily_run();
 hourly_run();
 realtime_run();

--- a/package.json
+++ b/package.json
@@ -62,7 +62,8 @@
     "lodash": "^3.10.1",
     "minimist": "*",
     "moment-timezone": "^0.5.11",
-    "node-schedule": "^0.1.13"
+    "node-schedule": "^0.1.13",
+    "winston-color": "^1.0.0"
   },
   "devDependencies": {
     "chai": "^3.5.0",

--- a/src/analytics.js
+++ b/src/analytics.js
@@ -11,24 +11,22 @@ var reports_path = config.reports_file || (path.join(process.cwd(), "reports/rep
 var reports = JSON.parse(fs.readFileSync(reports_path)).reports;
 var by_name = {};
 for (var i=0; i<reports.length; i++)
-    by_name[reports[i].name] = reports[i];
+  by_name[reports[i].name] = reports[i];
 
 // Google Analytics data fetching and transformation utilities.
 // This should really move to its own analytics.js file.
 var Analytics = {
+  reports: by_name,
 
-    reports: by_name,
+  query: function(report) {
+    if (!report) {
+      return Promise.reject("Analytics.query missing required argument `report`")
+    }
 
-    query: function(report, callback) {
-        if (!report) {
-            return callback()
-        }
-
-        return GoogleAnalyticsClient.fetchData(report).then(data => {
-            const processedData = GoogleAnalyticsDataProcessor.processData(report, data)
-            callback(null, processedData)
-        }).catch(callback)
-    },
+    return GoogleAnalyticsClient.fetchData(report).then(data => {
+      return GoogleAnalyticsDataProcessor.processData(report, data)
+    })
+  },
 };
 
 module.exports = Analytics;

--- a/src/process-results/result-formatter.js
+++ b/src/process-results/result-formatter.js
@@ -1,6 +1,6 @@
 const csv = require("fast-csv")
 
-const formatResult = (result, format, { slim = false } = {}) => {
+const formatResult = (result, { format = "json", slim = false } = {}) => {
   result = Object.assign({}, result)
 
   switch(format) {

--- a/test/process-results/result-formatter.test.js
+++ b/test/process-results/result-formatter.test.js
@@ -10,7 +10,7 @@ const GoogleAnalyticsDataProcessor = proxyquire("../../src/process-results/ga-da
 const ResultFormatter = require("../../src/process-results/result-formatter")
 
 describe("ResultFormatter", () => {
-  describe("formatResult(result, format, options)", () => {
+  describe("formatResult(result, options)", () => {
     let report
     let data
 
@@ -22,7 +22,7 @@ describe("ResultFormatter", () => {
     it("should format results into JSON if the format is 'json'", done => {
       const result = GoogleAnalyticsDataProcessor.processData(report, data)
 
-      ResultFormatter.formatResult(result, "json").then(formattedResult => {
+      ResultFormatter.formatResult(result, { format: "json" }).then(formattedResult => {
         const object = JSON.parse(formattedResult)
         expect(object).to.deep.equal(object)
         done()
@@ -32,7 +32,7 @@ describe("ResultFormatter", () => {
     it("should remove the data attribute for JSON if options.slim is true", done => {
       const result = GoogleAnalyticsDataProcessor.processData(report, data)
 
-      ResultFormatter.formatResult(result, "json", { slim: true }).then(formattedResult => {
+      ResultFormatter.formatResult(result, { format: "json", slim: true }).then(formattedResult => {
         const object = JSON.parse(formattedResult)
         expect(object.data).to.be.undefined
         done()
@@ -42,7 +42,7 @@ describe("ResultFormatter", () => {
     it("should format results into CSV if the format is 'csv'", done => {
       const result = GoogleAnalyticsDataProcessor.processData(report, data)
 
-      ResultFormatter.formatResult(result, "csv", { slim: true }).then(formattedResult => {
+      ResultFormatter.formatResult(result, { format: "csv", slim: true }).then(formattedResult => {
         csv.fromString(formattedResult, { strictColumnHandling: true }, { headers: true })
           .on("invalid-data", (data) => {
             done(new Error("Invalid CSV data: " + data))


### PR DESCRIPTION
This PR includes small changes to `index.js` to clean up code:

- Add `reportOptions` which include options relevant to each report. Use this to integrate better w/ other modules
- Return Promise from `Analytics.query` (see #209)
- Use winston to clean up logging