### PR TITLE
Add Docker Compose configuration

### DIFF
--- a/README.md
+++ b/README.md
@@ -327,7 +327,7 @@ cf restage analytics-reporter
 This repo contains a [Docker Compose](https://docs.docker.com/compose/)
 configuration. The reporter is configured to run in the container as if it were
 running in GovCloud. This is helpful for seeing how the reporter will behave
-when deployed without pushing it to cloud.gov
+when deployed without pushing it to cloud.gov.
 
 To start the reporter, first run the `docker-update` script to install the
 necessary dependencies:

--- a/README.md
+++ b/README.md
@@ -322,6 +322,30 @@ Restage the application to use the environment variables.
 cf restage analytics-reporter
 ```
 
+### Developing with Docker
+
+This repo contains a [Docker Compose](https://docs.docker.com/compose/)
+configuration. The reporter is configured to run in the container as if it were
+running in GovCloud. This is helpful for seeing how the reporter will behave
+when deployed without pushing it to cloud.gov
+
+To start the reporter, first run the `docker-update` script to install the
+necessary dependencies:
+
+```shell
+./bin/docker-update
+```
+
+Note that this script will need to be run again when new dependencies are added
+to update the Docker volumes where the dependencies are stored.
+
+After the dependencies are installed, the reporter can be started using Docker
+Compose:
+
+```shell
+docker-compose up
+```
+
 ### Public domain
 
 This project is in the worldwide [public domain](LICENSE.md). As stated in [CONTRIBUTING](CONTRIBUTING.md):

--- a/bin/docker-update
+++ b/bin/docker-update
@@ -1,0 +1,23 @@
+#!/bin/bash
+
+if docker-compose build; then
+  if docker-compose run reporter ./bin/update; then
+    echo
+    echo "Docker environment updated successfully."
+    exit 0
+  fi
+fi
+
+echo
+echo "Alas, something didn't work when trying to update your Docker setup."
+echo "If you're not sure what the problem is, you might want to just "
+echo "reset your environment by running:"
+echo
+echo "    docker-compose down -v"
+echo "    $0"
+echo
+echo "Note that this will reset your database! It will also re-fetch"
+echo "your package dependencies, among other things, so make sure you"
+echo "have a good internet connection."
+
+exit 1

--- a/bin/update
+++ b/bin/update
@@ -1,0 +1,3 @@
+#!/bin/bash
+
+npm install

--- a/bin/update
+++ b/bin/update
@@ -1,3 +1,4 @@
 #!/bin/bash
 
 npm install
+npm run migrate

--- a/deploy/api.sh
+++ b/deploy/api.sh
@@ -3,112 +3,112 @@
 export ANALYTICS_REPORTS_PATH=reports/api.json
 
 # Gov Wide
-$HOME/bin/analytics --verbose --write-to-database --output /tmp
+$ANALYTICS_ROOT_PATH/bin/analytics --verbose --write-to-database --output /tmp
 
 # Department of Education
-source $HOME/deploy/envs/education.env
-$HOME/bin/analytics --verbose --write-to-database --output /tmp
+source $ANALYTICS_ROOT_PATH/deploy/envs/education.env
+$ANALYTICS_ROOT_PATH/bin/analytics --verbose --write-to-database --output /tmp
 
 # Department of Veterans Affairs
-source $HOME/deploy/envs/veterans-affairs.env
-$HOME/bin/analytics --verbose --write-to-database --output /tmp
+source $ANALYTICS_ROOT_PATH/deploy/envs/veterans-affairs.env
+$ANALYTICS_ROOT_PATH/bin/analytics --verbose --write-to-database --output /tmp
 
 # National Aeronautics and Space Administration
-source $HOME/deploy/envs/national-aeronautics-space-administration.env
-$HOME/bin/analytics --verbose --write-to-database --output /tmp
+source $ANALYTICS_ROOT_PATH/deploy/envs/national-aeronautics-space-administration.env
+$ANALYTICS_ROOT_PATH/bin/analytics --verbose --write-to-database --output /tmp
 
 # Department of Justice
-source $HOME/deploy/envs/justice.env
-$HOME/bin/analytics --verbose --write-to-database --output /tmp
+source $ANALYTICS_ROOT_PATH/deploy/envs/justice.env
+$ANALYTICS_ROOT_PATH/bin/analytics --verbose --write-to-database --output /tmp
 
 # Department of Commerce
-source $HOME/deploy/envs/commerce.env
-$HOME/bin/analytics --verbose --write-to-database --output /tmp
+source $ANALYTICS_ROOT_PATH/deploy/envs/commerce.env
+$ANALYTICS_ROOT_PATH/bin/analytics --verbose --write-to-database --output /tmp
 
 # Environmental Protection Agency
-source $HOME/deploy/envs/environmental-protection-agency.env
-$HOME/bin/analytics --verbose --write-to-database --output /tmp
+source $ANALYTICS_ROOT_PATH/deploy/envs/environmental-protection-agency.env
+$ANALYTICS_ROOT_PATH/bin/analytics --verbose --write-to-database --output /tmp
 
 # Small Business Administration
-source $HOME/deploy/envs/small-business-administration.env
-$HOME/bin/analytics --verbose --write-to-database --output /tmp
+source $ANALYTICS_ROOT_PATH/deploy/envs/small-business-administration.env
+$ANALYTICS_ROOT_PATH/bin/analytics --verbose --write-to-database --output /tmp
 
 # Department of Energy
-source $HOME/deploy/envs/energy.env
-$HOME/bin/analytics --verbose --write-to-database --output /tmp
+source $ANALYTICS_ROOT_PATH/deploy/envs/energy.env
+$ANALYTICS_ROOT_PATH/bin/analytics --verbose --write-to-database --output /tmp
 
 # Department of the Interior
-source $HOME/deploy/envs/interior.env
-$HOME/bin/analytics --verbose --write-to-database --output /tmp
+source $ANALYTICS_ROOT_PATH/deploy/envs/interior.env
+$ANALYTICS_ROOT_PATH/bin/analytics --verbose --write-to-database --output /tmp
 
 # National Archives and Records Administration
-source $HOME/deploy/envs/national-archives-records-administration.env
-$HOME/bin/analytics --verbose --write-to-database --output /tmp
+source $ANALYTICS_ROOT_PATH/deploy/envs/national-archives-records-administration.env
+$ANALYTICS_ROOT_PATH/bin/analytics --verbose --write-to-database --output /tmp
 
 # Department of Agriculture
-source $HOME/deploy/envs/agriculture.env
-$HOME/bin/analytics --verbose --write-to-database --output /tmp
+source $ANALYTICS_ROOT_PATH/deploy/envs/agriculture.env
+$ANALYTICS_ROOT_PATH/bin/analytics --verbose --write-to-database --output /tmp
 
 # Department of Defense
-source $HOME/deploy/envs/defense.env
-$HOME/bin/analytics --verbose --write-to-database --output /tmp
+source $ANALYTICS_ROOT_PATH/deploy/envs/defense.env
+$ANALYTICS_ROOT_PATH/bin/analytics --verbose --write-to-database --output /tmp
 
 # Department of Health and Human Services
-source $HOME/deploy/envs/health-human-services.env
-$HOME/bin/analytics --verbose --write-to-database --output /tmp
+source $ANALYTICS_ROOT_PATH/deploy/envs/health-human-services.env
+$ANALYTICS_ROOT_PATH/bin/analytics --verbose --write-to-database --output /tmp
 
 # Department of Housing and Urban Development
-source $HOME/deploy/envs/housing-urban-development.env
-$HOME/bin/analytics --verbose --write-to-database --output /tmp
+source $ANALYTICS_ROOT_PATH/deploy/envs/housing-urban-development.env
+$ANALYTICS_ROOT_PATH/bin/analytics --verbose --write-to-database --output /tmp
 
 # Department of Homeland Security
-source $HOME/deploy/envs/homeland-security.env
-$HOME/bin/analytics --verbose --write-to-database --output /tmp
+source $ANALYTICS_ROOT_PATH/deploy/envs/homeland-security.env
+$ANALYTICS_ROOT_PATH/bin/analytics --verbose --write-to-database --output /tmp
 
 # Department of Labor
-source $HOME/deploy/envs/labor.env
-$HOME/bin/analytics --verbose --write-to-database --output /tmp
+source $ANALYTICS_ROOT_PATH/deploy/envs/labor.env
+$ANALYTICS_ROOT_PATH/bin/analytics --verbose --write-to-database --output /tmp
 
 # Department of State
-source $HOME/deploy/envs/state.env
-$HOME/bin/analytics --verbose --write-to-database --output /tmp
+source $ANALYTICS_ROOT_PATH/deploy/envs/state.env
+$ANALYTICS_ROOT_PATH/bin/analytics --verbose --write-to-database --output /tmp
 
 # Department of Transportation
-source $HOME/deploy/envs/transportation.env
-$HOME/bin/analytics --verbose --write-to-database --output /tmp
+source $ANALYTICS_ROOT_PATH/deploy/envs/transportation.env
+$ANALYTICS_ROOT_PATH/bin/analytics --verbose --write-to-database --output /tmp
 
 # Department of the Treasury
-source $HOME/deploy/envs/treasury.env
-$HOME/bin/analytics --verbose --write-to-database --output /tmp
+source $ANALYTICS_ROOT_PATH/deploy/envs/treasury.env
+$ANALYTICS_ROOT_PATH/bin/analytics --verbose --write-to-database --output /tmp
 
 # Agency for International Development
-source $HOME/deploy/envs/agency-international-development.env
-$HOME/bin/analytics --verbose --write-to-database --output /tmp
+source $ANALYTICS_ROOT_PATH/deploy/envs/agency-international-development.env
+$ANALYTICS_ROOT_PATH/bin/analytics --verbose --write-to-database --output /tmp
 
 # General Services Administration
-source $HOME/deploy/envs/general-services-administration.env
-$HOME/bin/analytics --verbose --write-to-database --output /tmp
+source $ANALYTICS_ROOT_PATH/deploy/envs/general-services-administration.env
+$ANALYTICS_ROOT_PATH/bin/analytics --verbose --write-to-database --output /tmp
 
 # National Science Foundation
-source $HOME/deploy/envs/national-science-foundation.env
-$HOME/bin/analytics --verbose --write-to-database --output /tmp
+source $ANALYTICS_ROOT_PATH/deploy/envs/national-science-foundation.env
+$ANALYTICS_ROOT_PATH/bin/analytics --verbose --write-to-database --output /tmp
 
 # Nuclear Regulatory Commission
-source $HOME/deploy/envs/nuclear-regulatory-commission.env
-$HOME/bin/analytics --verbose --write-to-database --output /tmp
+source $ANALYTICS_ROOT_PATH/deploy/envs/nuclear-regulatory-commission.env
+$ANALYTICS_ROOT_PATH/bin/analytics --verbose --write-to-database --output /tmp
 
 # Office of Personnel Management
-source $HOME/deploy/envs/office-personnel-management.env
-$HOME/bin/analytics --verbose --write-to-database --output /tmp
+source $ANALYTICS_ROOT_PATH/deploy/envs/office-personnel-management.env
+$ANALYTICS_ROOT_PATH/bin/analytics --verbose --write-to-database --output /tmp
 
 # Social Security Administration
-source $HOME/deploy/envs/social-security-administration.env
-$HOME/bin/analytics --verbose --write-to-database --output /tmp
+source $ANALYTICS_ROOT_PATH/deploy/envs/social-security-administration.env
+$ANALYTICS_ROOT_PATH/bin/analytics --verbose --write-to-database --output /tmp
 
 # Postal Service
-source $HOME/deploy/envs/postal-service.env
-$HOME/bin/analytics --verbose --write-to-database --output /tmp
+source $ANALYTICS_ROOT_PATH/deploy/envs/postal-service.env
+$ANALYTICS_ROOT_PATH/bin/analytics --verbose --write-to-database --output /tmp
 
 # Executive Office of the President
-source $HOME/deploy/envs/executive-office-president.env
-$HOME/bin/analytics --verbose --write-to-database --output /tmp
+source $ANALYTICS_ROOT_PATH/deploy/envs/executive-office-president.env
+$ANALYTICS_ROOT_PATH/bin/analytics --verbose --write-to-database --output /tmp

--- a/deploy/cron.js
+++ b/deploy/cron.js
@@ -1,3 +1,4 @@
+const spawn = require("child_process").spawn;
 const winston = require("winston-color")
 
 if (process.env.NEW_RELIC_APP_NAME) {
@@ -7,12 +8,12 @@ if (process.env.NEW_RELIC_APP_NAME) {
 	winston.warn("Skipping New Relic Activation")
 }
 
-const spawn = require("child_process").spawn;
+const scriptRootPath = `${process.env.ANALYTICS_ROOT_PATH}/deploy`
 
 var api_run = function() {
 	winston.info("about to run api.sh");
 
-	var api = spawn("./deploy/api.sh")
+	var api = spawn(`${scriptRootPath}/api.sh`)
 	api.stdout.on("data", (data) => {
 		winston.info("[api.sh]", data.toString().trim())
 	})
@@ -27,7 +28,7 @@ var api_run = function() {
 var daily_run = function() {
 	winston.info("about to run daily.sh");
 
-	var daily = spawn("./deploy/daily.sh")
+	var daily = spawn(`${scriptRootPath}/daily.sh`)
 	daily.stdout.on("data", (data) => {
 		winston.info("[daily.sh]", data.toString().trim())
 	})
@@ -42,7 +43,7 @@ var daily_run = function() {
 var hourly_run = function(){
 	winston.info("about to run hourly.sh");
 
-	var hourly = spawn("./deploy/hourly.sh")
+	var hourly = spawn(`${scriptRootPath}/hourly.sh`)
 	hourly.stdout.on("data", (data) => {
 		winston.info("[hourly.sh]", data.toString().trim())
 	})
@@ -57,7 +58,7 @@ var hourly_run = function(){
 var realtime_run = function(){
 	winston.info("about to run realtime.sh");
 
-	var realtime = spawn("./deploy/realtime.sh")
+	var realtime = spawn(`${scriptRootPath}/realtime.sh`)
 	realtime.stdout.on("data", (data) => {
 		winston.info("[realtime.sh]", data.toString().trim())
 	})

--- a/deploy/daily.sh
+++ b/deploy/daily.sh
@@ -1,140 +1,140 @@
 #!/bin/bash
 
-# JSON and CSV versions
-$HOME/bin/analytics --publish --frequency=daily --slim --verbose
-$HOME/bin/analytics --publish --frequency=daily --slim --verbose --csv
+# Government Wide
+$ANALYTICS_ROOT_PATH/bin/analytics --publish --frequency=daily --slim --verbose
+$ANALYTICS_ROOT_PATH/bin/analytics --publish --frequency=daily --slim --verbose --csv
 
 # Department of Education
-source $HOME/deploy/envs/education.env
-$HOME/bin/analytics --publish --frequency=daily --slim --verbose
-$HOME/bin/analytics --publish --frequency=daily --slim --verbose --csv
+source $ANALYTICS_ROOT_PATH/deploy/envs/education.env
+$ANALYTICS_ROOT_PATH/bin/analytics --publish --frequency=daily --slim --verbose
+$ANALYTICS_ROOT_PATH/bin/analytics --publish --frequency=daily --slim --verbose --csv
 
 # Department of Veterans Affairs
-source $HOME/deploy/envs/veterans-affairs.env
-$HOME/bin/analytics --publish --frequency=daily --slim --verbose
-$HOME/bin/analytics --publish --frequency=daily --slim --verbose --csv
+source $ANALYTICS_ROOT_PATH/deploy/envs/veterans-affairs.env
+$ANALYTICS_ROOT_PATH/bin/analytics --publish --frequency=daily --slim --verbose
+$ANALYTICS_ROOT_PATH/bin/analytics --publish --frequency=daily --slim --verbose --csv
 
 # National Aeronautics and Space Administration
-source $HOME/deploy/envs/national-aeronautics-space-administration.env
-$HOME/bin/analytics --publish --frequency=daily --slim --verbose
-$HOME/bin/analytics --publish --frequency=daily --slim --verbose --csv
+source $ANALYTICS_ROOT_PATH/deploy/envs/national-aeronautics-space-administration.env
+$ANALYTICS_ROOT_PATH/bin/analytics --publish --frequency=daily --slim --verbose
+$ANALYTICS_ROOT_PATH/bin/analytics --publish --frequency=daily --slim --verbose --csv
 
 # Department of Justice
-source $HOME/deploy/envs/justice.env
-$HOME/bin/analytics --publish --frequency=daily --slim --verbose
-$HOME/bin/analytics --publish --frequency=daily --slim --verbose --csv
+source $ANALYTICS_ROOT_PATH/deploy/envs/justice.env
+$ANALYTICS_ROOT_PATH/bin/analytics --publish --frequency=daily --slim --verbose
+$ANALYTICS_ROOT_PATH/bin/analytics --publish --frequency=daily --slim --verbose --csv
 
 # Department of Commerce
-source $HOME/deploy/envs/commerce.env
-$HOME/bin/analytics --publish --frequency=daily --slim --verbose
-$HOME/bin/analytics --publish --frequency=daily --slim --verbose --csv
+source $ANALYTICS_ROOT_PATH/deploy/envs/commerce.env
+$ANALYTICS_ROOT_PATH/bin/analytics --publish --frequency=daily --slim --verbose
+$ANALYTICS_ROOT_PATH/bin/analytics --publish --frequency=daily --slim --verbose --csv
 
 # Environmental Protection Agency
-source $HOME/deploy/envs/environmental-protection-agency.env
-$HOME/bin/analytics --publish --frequency=daily --slim --verbose
-$HOME/bin/analytics --publish --frequency=daily --slim --verbose --csv
+source $ANALYTICS_ROOT_PATH/deploy/envs/environmental-protection-agency.env
+$ANALYTICS_ROOT_PATH/bin/analytics --publish --frequency=daily --slim --verbose
+$ANALYTICS_ROOT_PATH/bin/analytics --publish --frequency=daily --slim --verbose --csv
 
 # Small Business Administration
-source $HOME/deploy/envs/small-business-administration.env
-$HOME/bin/analytics --publish --frequency=daily --slim --verbose
-$HOME/bin/analytics --publish --frequency=daily --slim --verbose --csv
+source $ANALYTICS_ROOT_PATH/deploy/envs/small-business-administration.env
+$ANALYTICS_ROOT_PATH/bin/analytics --publish --frequency=daily --slim --verbose
+$ANALYTICS_ROOT_PATH/bin/analytics --publish --frequency=daily --slim --verbose --csv
 
 # Department of Energy
-source $HOME/deploy/envs/energy.env
-$HOME/bin/analytics --publish --frequency=daily --slim --verbose
-$HOME/bin/analytics --publish --frequency=daily --slim --verbose --csv
+source $ANALYTICS_ROOT_PATH/deploy/envs/energy.env
+$ANALYTICS_ROOT_PATH/bin/analytics --publish --frequency=daily --slim --verbose
+$ANALYTICS_ROOT_PATH/bin/analytics --publish --frequency=daily --slim --verbose --csv
 
 # Department of the Interior
-source $HOME/deploy/envs/interior.env
-$HOME/bin/analytics --publish --frequency=daily --slim --verbose
-$HOME/bin/analytics --publish --frequency=daily --slim --verbose --csv
+source $ANALYTICS_ROOT_PATH/deploy/envs/interior.env
+$ANALYTICS_ROOT_PATH/bin/analytics --publish --frequency=daily --slim --verbose
+$ANALYTICS_ROOT_PATH/bin/analytics --publish --frequency=daily --slim --verbose --csv
 
 # National Archives and Records Administration
-source $HOME/deploy/envs/national-archives-records-administration.env
-$HOME/bin/analytics --publish --frequency=daily --slim --verbose
-$HOME/bin/analytics --publish --frequency=daily --slim --verbose --csv
+source $ANALYTICS_ROOT_PATH/deploy/envs/national-archives-records-administration.env
+$ANALYTICS_ROOT_PATH/bin/analytics --publish --frequency=daily --slim --verbose
+$ANALYTICS_ROOT_PATH/bin/analytics --publish --frequency=daily --slim --verbose --csv
 
 # Department of Agriculture
-source $HOME/deploy/envs/agriculture.env
-$HOME/bin/analytics --publish --frequency=daily --slim --verbose
-$HOME/bin/analytics --publish --frequency=daily --slim --verbose --csv
+source $ANALYTICS_ROOT_PATH/deploy/envs/agriculture.env
+$ANALYTICS_ROOT_PATH/bin/analytics --publish --frequency=daily --slim --verbose
+$ANALYTICS_ROOT_PATH/bin/analytics --publish --frequency=daily --slim --verbose --csv
 
 # Department of Defense
-source $HOME/deploy/envs/defense.env
-$HOME/bin/analytics --publish --frequency=daily --slim --verbose
-$HOME/bin/analytics --publish --frequency=daily --slim --verbose --csv
+source $ANALYTICS_ROOT_PATH/deploy/envs/defense.env
+$ANALYTICS_ROOT_PATH/bin/analytics --publish --frequency=daily --slim --verbose
+$ANALYTICS_ROOT_PATH/bin/analytics --publish --frequency=daily --slim --verbose --csv
 
 # Department of Health and Human Services
-source $HOME/deploy/envs/health-human-services.env
-$HOME/bin/analytics --publish --frequency=daily --slim --verbose
-$HOME/bin/analytics --publish --frequency=daily --slim --verbose --csv
+source $ANALYTICS_ROOT_PATH/deploy/envs/health-human-services.env
+$ANALYTICS_ROOT_PATH/bin/analytics --publish --frequency=daily --slim --verbose
+$ANALYTICS_ROOT_PATH/bin/analytics --publish --frequency=daily --slim --verbose --csv
 
 # Department of Housing and Urban Development
-source $HOME/deploy/envs/housing-urban-development.env
-$HOME/bin/analytics --publish --frequency=daily --slim --verbose
-$HOME/bin/analytics --publish --frequency=daily --slim --verbose --csv
+source $ANALYTICS_ROOT_PATH/deploy/envs/housing-urban-development.env
+$ANALYTICS_ROOT_PATH/bin/analytics --publish --frequency=daily --slim --verbose
+$ANALYTICS_ROOT_PATH/bin/analytics --publish --frequency=daily --slim --verbose --csv
 
 # Department of Homeland Security
-source $HOME/deploy/envs/homeland-security.env
-$HOME/bin/analytics --publish --frequency=daily --slim --verbose
-$HOME/bin/analytics --publish --frequency=daily --slim --verbose --csv
+source $ANALYTICS_ROOT_PATH/deploy/envs/homeland-security.env
+$ANALYTICS_ROOT_PATH/bin/analytics --publish --frequency=daily --slim --verbose
+$ANALYTICS_ROOT_PATH/bin/analytics --publish --frequency=daily --slim --verbose --csv
 
 # Department of Labor
-source $HOME/deploy/envs/labor.env
-$HOME/bin/analytics --publish --frequency=daily --slim --verbose
-$HOME/bin/analytics --publish --frequency=daily --slim --verbose --csv
+source $ANALYTICS_ROOT_PATH/deploy/envs/labor.env
+$ANALYTICS_ROOT_PATH/bin/analytics --publish --frequency=daily --slim --verbose
+$ANALYTICS_ROOT_PATH/bin/analytics --publish --frequency=daily --slim --verbose --csv
 
 # Department of State
-source $HOME/deploy/envs/state.env
-$HOME/bin/analytics --publish --frequency=daily --slim --verbose
-$HOME/bin/analytics --publish --frequency=daily --slim --verbose --csv
+source $ANALYTICS_ROOT_PATH/deploy/envs/state.env
+$ANALYTICS_ROOT_PATH/bin/analytics --publish --frequency=daily --slim --verbose
+$ANALYTICS_ROOT_PATH/bin/analytics --publish --frequency=daily --slim --verbose --csv
 
 # Department of Transportation
-source $HOME/deploy/envs/transportation.env
-$HOME/bin/analytics --publish --frequency=daily --slim --verbose
-$HOME/bin/analytics --publish --frequency=daily --slim --verbose --csv
+source $ANALYTICS_ROOT_PATH/deploy/envs/transportation.env
+$ANALYTICS_ROOT_PATH/bin/analytics --publish --frequency=daily --slim --verbose
+$ANALYTICS_ROOT_PATH/bin/analytics --publish --frequency=daily --slim --verbose --csv
 
 # Department of the Treasury
-source $HOME/deploy/envs/treasury.env
-$HOME/bin/analytics --publish --frequency=daily --slim --verbose
-$HOME/bin/analytics --publish --frequency=daily --slim --verbose --csv
+source $ANALYTICS_ROOT_PATH/deploy/envs/treasury.env
+$ANALYTICS_ROOT_PATH/bin/analytics --publish --frequency=daily --slim --verbose
+$ANALYTICS_ROOT_PATH/bin/analytics --publish --frequency=daily --slim --verbose --csv
 
 # Agency for International Development
-source $HOME/deploy/envs/agency-international-development.env
-$HOME/bin/analytics --publish --frequency=daily --slim --verbose
-$HOME/bin/analytics --publish --frequency=daily --slim --verbose --csv
+source $ANALYTICS_ROOT_PATH/deploy/envs/agency-international-development.env
+$ANALYTICS_ROOT_PATH/bin/analytics --publish --frequency=daily --slim --verbose
+$ANALYTICS_ROOT_PATH/bin/analytics --publish --frequency=daily --slim --verbose --csv
 
 # General Services Administration
-source $HOME/deploy/envs/general-services-administration.env
-$HOME/bin/analytics --publish --frequency=daily --slim --verbose
-$HOME/bin/analytics --publish --frequency=daily --slim --verbose --csv
+source $ANALYTICS_ROOT_PATH/deploy/envs/general-services-administration.env
+$ANALYTICS_ROOT_PATH/bin/analytics --publish --frequency=daily --slim --verbose
+$ANALYTICS_ROOT_PATH/bin/analytics --publish --frequency=daily --slim --verbose --csv
 
 # National Science Foundation
-source $HOME/deploy/envs/national-science-foundation.env
-$HOME/bin/analytics --publish --frequency=daily --slim --verbose
-$HOME/bin/analytics --publish --frequency=daily --slim --verbose --csv
+source $ANALYTICS_ROOT_PATH/deploy/envs/national-science-foundation.env
+$ANALYTICS_ROOT_PATH/bin/analytics --publish --frequency=daily --slim --verbose
+$ANALYTICS_ROOT_PATH/bin/analytics --publish --frequency=daily --slim --verbose --csv
 
 # Nuclear Regulatory Commission
-source $HOME/deploy/envs/nuclear-regulatory-commission.env
-$HOME/bin/analytics --publish --frequency=daily --slim --verbose
-$HOME/bin/analytics --publish --frequency=daily --slim --verbose --csv
+source $ANALYTICS_ROOT_PATH/deploy/envs/nuclear-regulatory-commission.env
+$ANALYTICS_ROOT_PATH/bin/analytics --publish --frequency=daily --slim --verbose
+$ANALYTICS_ROOT_PATH/bin/analytics --publish --frequency=daily --slim --verbose --csv
 
 # Office of Personnel Management
-source $HOME/deploy/envs/office-personnel-management.env
-$HOME/bin/analytics --publish --frequency=daily --slim --verbose
-$HOME/bin/analytics --publish --frequency=daily --slim --verbose --csv
+source $ANALYTICS_ROOT_PATH/deploy/envs/office-personnel-management.env
+$ANALYTICS_ROOT_PATH/bin/analytics --publish --frequency=daily --slim --verbose
+$ANALYTICS_ROOT_PATH/bin/analytics --publish --frequency=daily --slim --verbose --csv
 
 # Social Security Administration
-source $HOME/deploy/envs/social-security-administration.env
-$HOME/bin/analytics --publish --frequency=daily --slim --verbose
-$HOME/bin/analytics --publish --frequency=daily --slim --verbose --csv
+source $ANALYTICS_ROOT_PATH/deploy/envs/social-security-administration.env
+$ANALYTICS_ROOT_PATH/bin/analytics --publish --frequency=daily --slim --verbose
+$ANALYTICS_ROOT_PATH/bin/analytics --publish --frequency=daily --slim --verbose --csv
 
 # Postal Service
-source $HOME/deploy/envs/postal-service.env
-$HOME/bin/analytics --publish --frequency=daily --slim --verbose
-$HOME/bin/analytics --publish --frequency=daily --slim --verbose --csv
+source $ANALYTICS_ROOT_PATH/deploy/envs/postal-service.env
+$ANALYTICS_ROOT_PATH/bin/analytics --publish --frequency=daily --slim --verbose
+$ANALYTICS_ROOT_PATH/bin/analytics --publish --frequency=daily --slim --verbose --csv
 
 # Executive Office of the President
-source $HOME/deploy/envs/executive-office-president.env
-$HOME/bin/analytics --publish --frequency=daily --slim --verbose
-$HOME/bin/analytics --publish --frequency=daily --slim --verbose --csv
+source $ANALYTICS_ROOT_PATH/deploy/envs/executive-office-president.env
+$ANALYTICS_ROOT_PATH/bin/analytics --publish --frequency=daily --slim --verbose
+$ANALYTICS_ROOT_PATH/bin/analytics --publish --frequency=daily --slim --verbose --csv

--- a/deploy/hourly.sh
+++ b/deploy/hourly.sh
@@ -1,115 +1,112 @@
 #!/bin/bash
 
-export PATH=$PATH:/usr/local/bin
-source $HOME/.bashrc
-
-# just the one awkward 'today' report
-$HOME/bin/analytics --publish --frequency=hourly --slim --verbose
+# Government Wide
+$ANALYTICS_ROOT_PATH/bin/analytics --publish --frequency=hourly --slim --verbose
 
 # Department of Education
-source $HOME/deploy/envs/education.env
-$HOME/bin/analytics --publish --frequency=hourly --slim --verbose
+source $ANALYTICS_ROOT_PATH/deploy/envs/education.env
+$ANALYTICS_ROOT_PATH/bin/analytics --publish --frequency=hourly --slim --verbose
 
 # National Aeronautics and Space Administration
-source $HOME/deploy/envs/national-aeronautics-space-administration.env
-$HOME/bin/analytics --publish --frequency=hourly --slim --verbose
+source $ANALYTICS_ROOT_PATH/deploy/envs/national-aeronautics-space-administration.env
+$ANALYTICS_ROOT_PATH/bin/analytics --publish --frequency=hourly --slim --verbose
 
 # Department of Justice
-source $HOME/deploy/envs/justice.env
-$HOME/bin/analytics --publish --frequency=hourly --slim --verbose
+source $ANALYTICS_ROOT_PATH/deploy/envs/justice.env
+$ANALYTICS_ROOT_PATH/bin/analytics --publish --frequency=hourly --slim --verbose
 
 # Department of Veterans Affairs
-source $HOME/deploy/envs/veterans-affairs.env
-$HOME/bin/analytics --publish --frequency=hourly --slim --verbose
+source $ANALYTICS_ROOT_PATH/deploy/envs/veterans-affairs.env
+$ANALYTICS_ROOT_PATH/bin/analytics --publish --frequency=hourly --slim --verbose
 
 # Department of Commerce
-source $HOME/deploy/envs/commerce.env
-$HOME/bin/analytics --publish --frequency=hourly --slim --verbose
+source $ANALYTICS_ROOT_PATH/deploy/envs/commerce.env
+$ANALYTICS_ROOT_PATH/bin/analytics --publish --frequency=hourly --slim --verbose
 
 # Environmental Protection Agency
-source $HOME/deploy/envs/environmental-protection-agency.env
-$HOME/bin/analytics --publish --frequency=hourly --slim --verbose
+source $ANALYTICS_ROOT_PATH/deploy/envs/environmental-protection-agency.env
+$ANALYTICS_ROOT_PATH/bin/analytics --publish --frequency=hourly --slim --verbose
 
 # Small Business Administration
-source $HOME/deploy/envs/small-business-administration.env
-$HOME/bin/analytics --publish --frequency=hourly --slim --verbose
+source $ANALYTICS_ROOT_PATH/deploy/envs/small-business-administration.env
+$ANALYTICS_ROOT_PATH/bin/analytics --publish --frequency=hourly --slim --verbose
 
 # Department of Energy
-source $HOME/deploy/envs/energy.env
-$HOME/bin/analytics --publish --frequency=hourly --slim --verbose
+source $ANALYTICS_ROOT_PATH/deploy/envs/energy.env
+$ANALYTICS_ROOT_PATH/bin/analytics --publish --frequency=hourly --slim --verbose
 
 # Department of the Interior
-source $HOME/deploy/envs/interior.env
-$HOME/bin/analytics --publish --frequency=hourly --slim --verbose
+source $ANALYTICS_ROOT_PATH/deploy/envs/interior.env
+$ANALYTICS_ROOT_PATH/bin/analytics --publish --frequency=hourly --slim --verbose
 
 # National Archives and Records Administration
-source $HOME/deploy/envs/national-archives-records-administration.env
-$HOME/bin/analytics --publish --frequency=hourly --slim --verbose
+source $ANALYTICS_ROOT_PATH/deploy/envs/national-archives-records-administration.env
+$ANALYTICS_ROOT_PATH/bin/analytics --publish --frequency=hourly --slim --verbose
 
 # Department of Agriculture
-source $HOME/deploy/envs/agriculture.env
-$HOME/bin/analytics --publish --frequency=hourly --slim --verbose
+source $ANALYTICS_ROOT_PATH/deploy/envs/agriculture.env
+$ANALYTICS_ROOT_PATH/bin/analytics --publish --frequency=hourly --slim --verbose
 
 # Department of Defense
-source $HOME/deploy/envs/defense.env
-$HOME/bin/analytics --publish --frequency=hourly --slim --verbose
+source $ANALYTICS_ROOT_PATH/deploy/envs/defense.env
+$ANALYTICS_ROOT_PATH/bin/analytics --publish --frequency=hourly --slim --verbose
 
 # Department of Health and Human Services
-source $HOME/deploy/envs/health-human-services.env
-$HOME/bin/analytics --publish --frequency=hourly --slim --verbose
+source $ANALYTICS_ROOT_PATH/deploy/envs/health-human-services.env
+$ANALYTICS_ROOT_PATH/bin/analytics --publish --frequency=hourly --slim --verbose
 
 # Department of Housing and Urban Development
-source $HOME/deploy/envs/housing-urban-development.env
-$HOME/bin/analytics --publish --frequency=hourly --slim --verbose
+source $ANALYTICS_ROOT_PATH/deploy/envs/housing-urban-development.env
+$ANALYTICS_ROOT_PATH/bin/analytics --publish --frequency=hourly --slim --verbose
 
 # Department of Homeland Security
-source $HOME/deploy/envs/homeland-security.env
-$HOME/bin/analytics --publish --frequency=hourly --slim --verbose
+source $ANALYTICS_ROOT_PATH/deploy/envs/homeland-security.env
+$ANALYTICS_ROOT_PATH/bin/analytics --publish --frequency=hourly --slim --verbose
 
 # Department of Labor
-source $HOME/deploy/envs/labor.env
-$HOME/bin/analytics --publish --frequency=hourly --slim --verbose
+source $ANALYTICS_ROOT_PATH/deploy/envs/labor.env
+$ANALYTICS_ROOT_PATH/bin/analytics --publish --frequency=hourly --slim --verbose
 
 # Department of State
-source $HOME/deploy/envs/state.env
-$HOME/bin/analytics --publish --frequency=hourly --slim --verbose
+source $ANALYTICS_ROOT_PATH/deploy/envs/state.env
+$ANALYTICS_ROOT_PATH/bin/analytics --publish --frequency=hourly --slim --verbose
 
 # Department of Transportation
-source $HOME/deploy/envs/transportation.env
-$HOME/bin/analytics --publish --frequency=hourly --slim --verbose
+source $ANALYTICS_ROOT_PATH/deploy/envs/transportation.env
+$ANALYTICS_ROOT_PATH/bin/analytics --publish --frequency=hourly --slim --verbose
 
 # Department of the Treasury
-source $HOME/deploy/envs/treasury.env
-$HOME/bin/analytics --publish --frequency=hourly --slim --verbose
+source $ANALYTICS_ROOT_PATH/deploy/envs/treasury.env
+$ANALYTICS_ROOT_PATH/bin/analytics --publish --frequency=hourly --slim --verbose
 
 # Agency for International Development
-source $HOME/deploy/envs/agency-international-development.env
-$HOME/bin/analytics --publish --frequency=hourly --slim --verbose
+source $ANALYTICS_ROOT_PATH/deploy/envs/agency-international-development.env
+$ANALYTICS_ROOT_PATH/bin/analytics --publish --frequency=hourly --slim --verbose
 
 # General Services Administration
-source $HOME/deploy/envs/general-services-administration.env
-$HOME/bin/analytics --publish --frequency=hourly --slim --verbose
+source $ANALYTICS_ROOT_PATH/deploy/envs/general-services-administration.env
+$ANALYTICS_ROOT_PATH/bin/analytics --publish --frequency=hourly --slim --verbose
 
 # National Science Foundation
-source $HOME/deploy/envs/national-science-foundation.env
-$HOME/bin/analytics --publish --frequency=hourly --slim --verbose
+source $ANALYTICS_ROOT_PATH/deploy/envs/national-science-foundation.env
+$ANALYTICS_ROOT_PATH/bin/analytics --publish --frequency=hourly --slim --verbose
 
 # Nuclear Regulatory Commission
-source $HOME/deploy/envs/nuclear-regulatory-commission.env
-$HOME/bin/analytics --publish --frequency=hourly --slim --verbose
+source $ANALYTICS_ROOT_PATH/deploy/envs/nuclear-regulatory-commission.env
+$ANALYTICS_ROOT_PATH/bin/analytics --publish --frequency=hourly --slim --verbose
 
 # Office of Personnel Management
-source $HOME/deploy/envs/office-personnel-management.env
-$HOME/bin/analytics --publish --frequency=hourly --slim --verbose
+source $ANALYTICS_ROOT_PATH/deploy/envs/office-personnel-management.env
+$ANALYTICS_ROOT_PATH/bin/analytics --publish --frequency=hourly --slim --verbose
 
 # Social Security Administration
-source $HOME/deploy/envs/social-security-administration.env
-$HOME/bin/analytics --publish --frequency=hourly --slim --verbose
+source $ANALYTICS_ROOT_PATH/deploy/envs/social-security-administration.env
+$ANALYTICS_ROOT_PATH/bin/analytics --publish --frequency=hourly --slim --verbose
 
 # Postal Service
-source $HOME/deploy/envs/postal-service.env
-$HOME/bin/analytics --publish --frequency=hourly --slim --verbose
+source $ANALYTICS_ROOT_PATH/deploy/envs/postal-service.env
+$ANALYTICS_ROOT_PATH/bin/analytics --publish --frequency=hourly --slim --verbose
 
 # Executive Office of the President
-source $HOME/deploy/envs/executive-office-president.env
-$HOME/bin/analytics --publish --frequency=hourly --slim --verbose
+source $ANALYTICS_ROOT_PATH/deploy/envs/executive-office-president.env
+$ANALYTICS_ROOT_PATH/bin/analytics --publish --frequency=hourly --slim --verbose

--- a/deploy/realtime.sh
+++ b/deploy/realtime.sh
@@ -1,143 +1,141 @@
 #!/bin/bash
 
-export PATH=$PATH:/usr/local/bin
-source $HOME/.bashrc
-
-$HOME/bin/analytics --publish --frequency=realtime --slim --verbose
+# Government Wide
+$ANALYTICS_ROOT_PATH/bin/analytics --publish --frequency=realtime --slim --verbose
 # we want just one realtime report in CSV, hardcoded for now to save on API requests
-$HOME/bin/analytics --publish --only=all-pages-realtime --slim --verbose --csv
+$ANALYTICS_ROOT_PATH/bin/analytics --publish --only=all-pages-realtime --slim --verbose --csv
 
 # Department of Education
-source $HOME/deploy/envs/education.env
-$HOME/bin/analytics --publish --frequency=realtime --slim --verbose
-$HOME/bin/analytics --publish --only=all-pages-realtime --slim --verbose --csv
+source $ANALYTICS_ROOT_PATH/deploy/envs/education.env
+$ANALYTICS_ROOT_PATH/bin/analytics --publish --frequency=realtime --slim --verbose
+$ANALYTICS_ROOT_PATH/bin/analytics --publish --only=all-pages-realtime --slim --verbose --csv
 
 # Department of Veterans Affairs
-source $HOME/deploy/envs/veterans-affairs.env
-$HOME/bin/analytics --publish --frequency=realtime --slim --verbose
-$HOME/bin/analytics --publish --only=all-pages-realtime --slim --verbose --csv
+source $ANALYTICS_ROOT_PATH/deploy/envs/veterans-affairs.env
+$ANALYTICS_ROOT_PATH/bin/analytics --publish --frequency=realtime --slim --verbose
+$ANALYTICS_ROOT_PATH/bin/analytics --publish --only=all-pages-realtime --slim --verbose --csv
 
 # National Aeronautics and Space Administration
-source $HOME/deploy/envs/national-aeronautics-space-administration.env
-$HOME/bin/analytics --publish --frequency=realtime --slim --verbose
-$HOME/bin/analytics --publish --only=all-pages-realtime --slim --verbose --csv
+source $ANALYTICS_ROOT_PATH/deploy/envs/national-aeronautics-space-administration.env
+$ANALYTICS_ROOT_PATH/bin/analytics --publish --frequency=realtime --slim --verbose
+$ANALYTICS_ROOT_PATH/bin/analytics --publish --only=all-pages-realtime --slim --verbose --csv
 
 # Department of Justice
-source $HOME/deploy/envs/justice.env
-$HOME/bin/analytics --publish --frequency=realtime --slim --verbose
-$HOME/bin/analytics --publish --only=all-pages-realtime --slim --verbose --csv
+source $ANALYTICS_ROOT_PATH/deploy/envs/justice.env
+$ANALYTICS_ROOT_PATH/bin/analytics --publish --frequency=realtime --slim --verbose
+$ANALYTICS_ROOT_PATH/bin/analytics --publish --only=all-pages-realtime --slim --verbose --csv
 
 # Department of Commerce
-source $HOME/deploy/envs/commerce.env
-$HOME/bin/analytics --publish --frequency=realtime --slim --verbose
-$HOME/bin/analytics --publish --only=all-pages-realtime --slim --verbose --csv
+source $ANALYTICS_ROOT_PATH/deploy/envs/commerce.env
+$ANALYTICS_ROOT_PATH/bin/analytics --publish --frequency=realtime --slim --verbose
+$ANALYTICS_ROOT_PATH/bin/analytics --publish --only=all-pages-realtime --slim --verbose --csv
 
 # Environmental Protection Agency
-source $HOME/deploy/envs/environmental-protection-agency.env
-$HOME/bin/analytics --publish --frequency=realtime --slim --verbose
-$HOME/bin/analytics --publish --only=all-pages-realtime --slim --verbose --csv
+source $ANALYTICS_ROOT_PATH/deploy/envs/environmental-protection-agency.env
+$ANALYTICS_ROOT_PATH/bin/analytics --publish --frequency=realtime --slim --verbose
+$ANALYTICS_ROOT_PATH/bin/analytics --publish --only=all-pages-realtime --slim --verbose --csv
 
 # Small Business Administration
-source $HOME/deploy/envs/small-business-administration.env
-$HOME/bin/analytics --publish --frequency=realtime --slim --verbose
-$HOME/bin/analytics --publish --only=all-pages-realtime --slim --verbose --csv
+source $ANALYTICS_ROOT_PATH/deploy/envs/small-business-administration.env
+$ANALYTICS_ROOT_PATH/bin/analytics --publish --frequency=realtime --slim --verbose
+$ANALYTICS_ROOT_PATH/bin/analytics --publish --only=all-pages-realtime --slim --verbose --csv
 
 # Department of Energy
-source $HOME/deploy/envs/energy.env
-$HOME/bin/analytics --publish --frequency=realtime --slim --verbose
-$HOME/bin/analytics --publish --only=all-pages-realtime --slim --verbose --csv
+source $ANALYTICS_ROOT_PATH/deploy/envs/energy.env
+$ANALYTICS_ROOT_PATH/bin/analytics --publish --frequency=realtime --slim --verbose
+$ANALYTICS_ROOT_PATH/bin/analytics --publish --only=all-pages-realtime --slim --verbose --csv
 
 # Department of the Interior
-source $HOME/deploy/envs/interior.env
-$HOME/bin/analytics --publish --frequency=realtime --slim --verbose
-$HOME/bin/analytics --publish --only=all-pages-realtime --slim --verbose --csv
+source $ANALYTICS_ROOT_PATH/deploy/envs/interior.env
+$ANALYTICS_ROOT_PATH/bin/analytics --publish --frequency=realtime --slim --verbose
+$ANALYTICS_ROOT_PATH/bin/analytics --publish --only=all-pages-realtime --slim --verbose --csv
 
 # National Archives and Records Administration
-source $HOME/deploy/envs/national-archives-records-administration.env
-$HOME/bin/analytics --publish --frequency=realtime --slim --verbose
-$HOME/bin/analytics --publish --only=all-pages-realtime --slim --verbose --csv
+source $ANALYTICS_ROOT_PATH/deploy/envs/national-archives-records-administration.env
+$ANALYTICS_ROOT_PATH/bin/analytics --publish --frequency=realtime --slim --verbose
+$ANALYTICS_ROOT_PATH/bin/analytics --publish --only=all-pages-realtime --slim --verbose --csv
 
 # Department of Agriculture
-source $HOME/deploy/envs/agriculture.env
-$HOME/bin/analytics --publish --frequency=realtime --slim --verbose
-$HOME/bin/analytics --publish --only=all-pages-realtime --slim --verbose --csv
+source $ANALYTICS_ROOT_PATH/deploy/envs/agriculture.env
+$ANALYTICS_ROOT_PATH/bin/analytics --publish --frequency=realtime --slim --verbose
+$ANALYTICS_ROOT_PATH/bin/analytics --publish --only=all-pages-realtime --slim --verbose --csv
 
 # Department of Defense
-source $HOME/deploy/envs/defense.env
-$HOME/bin/analytics --publish --frequency=realtime --slim --verbose
-$HOME/bin/analytics --publish --only=all-pages-realtime --slim --verbose --csv
+source $ANALYTICS_ROOT_PATH/deploy/envs/defense.env
+$ANALYTICS_ROOT_PATH/bin/analytics --publish --frequency=realtime --slim --verbose
+$ANALYTICS_ROOT_PATH/bin/analytics --publish --only=all-pages-realtime --slim --verbose --csv
 
 # Department of Health and Human Services
-source $HOME/deploy/envs/health-human-services.env
-$HOME/bin/analytics --publish --frequency=realtime --slim --verbose
-$HOME/bin/analytics --publish --only=all-pages-realtime --slim --verbose --csv
+source $ANALYTICS_ROOT_PATH/deploy/envs/health-human-services.env
+$ANALYTICS_ROOT_PATH/bin/analytics --publish --frequency=realtime --slim --verbose
+$ANALYTICS_ROOT_PATH/bin/analytics --publish --only=all-pages-realtime --slim --verbose --csv
 
 # Department of Housing and Urban Development
-source $HOME/deploy/envs/housing-urban-development.env
-$HOME/bin/analytics --publish --frequency=realtime --slim --verbose
-$HOME/bin/analytics --publish --only=all-pages-realtime --slim --verbose --csv
+source $ANALYTICS_ROOT_PATH/deploy/envs/housing-urban-development.env
+$ANALYTICS_ROOT_PATH/bin/analytics --publish --frequency=realtime --slim --verbose
+$ANALYTICS_ROOT_PATH/bin/analytics --publish --only=all-pages-realtime --slim --verbose --csv
 
 # Department of Homeland Security
-source $HOME/deploy/envs/homeland-security.env
-$HOME/bin/analytics --publish --frequency=realtime --slim --verbose
-$HOME/bin/analytics --publish --only=all-pages-realtime --slim --verbose --csv
+source $ANALYTICS_ROOT_PATH/deploy/envs/homeland-security.env
+$ANALYTICS_ROOT_PATH/bin/analytics --publish --frequency=realtime --slim --verbose
+$ANALYTICS_ROOT_PATH/bin/analytics --publish --only=all-pages-realtime --slim --verbose --csv
 
 # Department of Labor
-source $HOME/deploy/envs/labor.env
-$HOME/bin/analytics --publish --frequency=realtime --slim --verbose
-$HOME/bin/analytics --publish --only=all-pages-realtime --slim --verbose --csv
+source $ANALYTICS_ROOT_PATH/deploy/envs/labor.env
+$ANALYTICS_ROOT_PATH/bin/analytics --publish --frequency=realtime --slim --verbose
+$ANALYTICS_ROOT_PATH/bin/analytics --publish --only=all-pages-realtime --slim --verbose --csv
 
 # Department of State
-source $HOME/deploy/envs/state.env
-$HOME/bin/analytics --publish --frequency=realtime --slim --verbose
-$HOME/bin/analytics --publish --only=all-pages-realtime --slim --verbose --csv
+source $ANALYTICS_ROOT_PATH/deploy/envs/state.env
+$ANALYTICS_ROOT_PATH/bin/analytics --publish --frequency=realtime --slim --verbose
+$ANALYTICS_ROOT_PATH/bin/analytics --publish --only=all-pages-realtime --slim --verbose --csv
 
 # Department of Transportation
-source $HOME/deploy/envs/transportation.env
-$HOME/bin/analytics --publish --frequency=realtime --slim --verbose
-$HOME/bin/analytics --publish --only=all-pages-realtime --slim --verbose --csv
+source $ANALYTICS_ROOT_PATH/deploy/envs/transportation.env
+$ANALYTICS_ROOT_PATH/bin/analytics --publish --frequency=realtime --slim --verbose
+$ANALYTICS_ROOT_PATH/bin/analytics --publish --only=all-pages-realtime --slim --verbose --csv
 
 # Department of the Treasury
-source $HOME/deploy/envs/treasury.env
-$HOME/bin/analytics --publish --frequency=realtime --slim --verbose
-$HOME/bin/analytics --publish --only=all-pages-realtime --slim --verbose --csv
+source $ANALYTICS_ROOT_PATH/deploy/envs/treasury.env
+$ANALYTICS_ROOT_PATH/bin/analytics --publish --frequency=realtime --slim --verbose
+$ANALYTICS_ROOT_PATH/bin/analytics --publish --only=all-pages-realtime --slim --verbose --csv
 
 # Agency for International Development
-source $HOME/deploy/envs/agency-international-development.env
-$HOME/bin/analytics --publish --frequency=realtime --slim --verbose
-$HOME/bin/analytics --publish --only=all-pages-realtime --slim --verbose --csv
+source $ANALYTICS_ROOT_PATH/deploy/envs/agency-international-development.env
+$ANALYTICS_ROOT_PATH/bin/analytics --publish --frequency=realtime --slim --verbose
+$ANALYTICS_ROOT_PATH/bin/analytics --publish --only=all-pages-realtime --slim --verbose --csv
 
 # General Services Administration
-source $HOME/deploy/envs/general-services-administration.env
-$HOME/bin/analytics --publish --frequency=realtime --slim --verbose
-$HOME/bin/analytics --publish --only=all-pages-realtime --slim --verbose --csv
+source $ANALYTICS_ROOT_PATH/deploy/envs/general-services-administration.env
+$ANALYTICS_ROOT_PATH/bin/analytics --publish --frequency=realtime --slim --verbose
+$ANALYTICS_ROOT_PATH/bin/analytics --publish --only=all-pages-realtime --slim --verbose --csv
 
 # National Science Foundation
-source $HOME/deploy/envs/national-science-foundation.env
-$HOME/bin/analytics --publish --frequency=realtime --slim --verbose
-$HOME/bin/analytics --publish --only=all-pages-realtime --slim --verbose --csv
+source $ANALYTICS_ROOT_PATH/deploy/envs/national-science-foundation.env
+$ANALYTICS_ROOT_PATH/bin/analytics --publish --frequency=realtime --slim --verbose
+$ANALYTICS_ROOT_PATH/bin/analytics --publish --only=all-pages-realtime --slim --verbose --csv
 
 # Nuclear Regulatory Commission
-source $HOME/deploy/envs/nuclear-regulatory-commission.env
-$HOME/bin/analytics --publish --frequency=realtime --slim --verbose
-$HOME/bin/analytics --publish --only=all-pages-realtime --slim --verbose --csv
+source $ANALYTICS_ROOT_PATH/deploy/envs/nuclear-regulatory-commission.env
+$ANALYTICS_ROOT_PATH/bin/analytics --publish --frequency=realtime --slim --verbose
+$ANALYTICS_ROOT_PATH/bin/analytics --publish --only=all-pages-realtime --slim --verbose --csv
 
 # Office of Personnel Management
-source $HOME/deploy/envs/office-personnel-management.env
-$HOME/bin/analytics --publish --frequency=realtime --slim --verbose
-$HOME/bin/analytics --publish --only=all-pages-realtime --slim --verbose --csv
+source $ANALYTICS_ROOT_PATH/deploy/envs/office-personnel-management.env
+$ANALYTICS_ROOT_PATH/bin/analytics --publish --frequency=realtime --slim --verbose
+$ANALYTICS_ROOT_PATH/bin/analytics --publish --only=all-pages-realtime --slim --verbose --csv
 
 # Social Security Administration
-source $HOME/deploy/envs/social-security-administration.env
-$HOME/bin/analytics --publish --frequency=realtime --slim --verbose
-$HOME/bin/analytics --publish --only=all-pages-realtime --slim --verbose --csv
+source $ANALYTICS_ROOT_PATH/deploy/envs/social-security-administration.env
+$ANALYTICS_ROOT_PATH/bin/analytics --publish --frequency=realtime --slim --verbose
+$ANALYTICS_ROOT_PATH/bin/analytics --publish --only=all-pages-realtime --slim --verbose --csv
 
 # Postal Service
-source $HOME/deploy/envs/postal-service.env
-$HOME/bin/analytics --publish --frequency=realtime --slim --verbose
-$HOME/bin/analytics --publish --only=all-pages-realtime --slim --verbose --csv
+source $ANALYTICS_ROOT_PATH/deploy/envs/postal-service.env
+$ANALYTICS_ROOT_PATH/bin/analytics --publish --frequency=realtime --slim --verbose
+$ANALYTICS_ROOT_PATH/bin/analytics --publish --only=all-pages-realtime --slim --verbose --csv
 
 # Executive Office of the President
-source $HOME/deploy/envs/executive-office-president.env
-$HOME/bin/analytics --publish --frequency=realtime --slim --verbose
-$HOME/bin/analytics --publish --only=all-pages-realtime --slim --verbose --csv
+source $ANALYTICS_ROOT_PATH/deploy/envs/executive-office-president.env
+$ANALYTICS_ROOT_PATH/bin/analytics --publish --frequency=realtime --slim --verbose
+$ANALYTICS_ROOT_PATH/bin/analytics --publish --only=all-pages-realtime --slim --verbose --csv

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -1,0 +1,24 @@
+version: "3.0"
+services:
+  reporter:
+    command: node ./deploy/cron.js
+    environment:
+      - ANALYTICS_ROOT_PATH=/usr/src/reporter
+      - ANALYTICS_CREDENTIALS=${ANALYTICS_CREDENTIALS}
+      - ANALYTICS_REPORTS_PATH=${ANALYTICS_REPORTS_PATH}
+      - ANALYTICS_REPORT_IDS=${ANALYTICS_REPORT_IDS}
+      - AWS_ACCESS_KEY_ID=${AWS_ACCESS_KEY_ID}
+      - AWS_BUCKET=${AWS_BUCKET}
+      - AWS_BUCKET_PATH=${AWS_BUCKET_PATH}
+      - AWS_CACHE_TIME=${AWS_CACHE_TIME}
+      - AWS_DEFAULT_REGION=${AWS_DEFAULT_REGION}
+      - AWS_REGION=${AWS_REGION}
+      - AWS_SECRET_ACCESS_KEY=${AWS_SECRET_ACCESS_KEY}
+      - BUCKET_NAME=${BUCKET_NAME}
+    image: node:7.7
+    volumes:
+      - .:/usr/src/reporter
+      - node_modules:/usr/src/reporter/node_modules
+    working_dir: /usr/src/reporter
+volumes:
+  node_modules:

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -1,5 +1,12 @@
 version: "3.0"
 services:
+  db:
+    image: postgres:9.6
+    environment:
+      - POSTGRES_DB=analytics-reporter
+      - POSTGRES_USER=analytics
+    volumes:
+       - pgdata:/var/lib/postgresql/data/
   reporter:
     command: node ./deploy/cron.js
     environment:
@@ -15,10 +22,16 @@ services:
       - AWS_REGION=${AWS_REGION}
       - AWS_SECRET_ACCESS_KEY=${AWS_SECRET_ACCESS_KEY}
       - BUCKET_NAME=${BUCKET_NAME}
+      - POSTGRES_HOST=db
+      - POSTGRES_USER=analytics
+      - POSTGRES_DATABASE=analytics-reporter
     image: node:7.7
+    links:
+      - db
     volumes:
       - .:/usr/src/reporter
       - node_modules:/usr/src/reporter/node_modules
     working_dir: /usr/src/reporter
 volumes:
   node_modules:
+  pgdata:

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -8,9 +8,11 @@ services:
     volumes:
        - pgdata:/var/lib/postgresql/data/
   reporter:
-    command: node ./deploy/cron.js
+    image: node:7.8
+    entrypoint: ""
+    command: "node ./deploy/cron.js"
     environment:
-      - ANALYTICS_ROOT_PATH=/usr/src/reporter
+      - ANALYTICS_ROOT_PATH=/usr/src/app
       - ANALYTICS_CREDENTIALS=${ANALYTICS_CREDENTIALS}
       - ANALYTICS_REPORTS_PATH=${ANALYTICS_REPORTS_PATH}
       - ANALYTICS_REPORT_IDS=${ANALYTICS_REPORT_IDS}
@@ -25,13 +27,12 @@ services:
       - POSTGRES_HOST=db
       - POSTGRES_USER=analytics
       - POSTGRES_DATABASE=analytics-reporter
-    image: node:7.7
     links:
       - db
+    working_dir: /usr/src/app
     volumes:
-      - .:/usr/src/reporter
-      - node_modules:/usr/src/reporter/node_modules
-    working_dir: /usr/src/reporter
+      - .:/usr/src/app
+      - node_modules:/usr/src/app/node_modules
 volumes:
   node_modules:
   pgdata:

--- a/knexfile.js
+++ b/knexfile.js
@@ -1,0 +1,17 @@
+const config = require("./src/config")
+
+module.exports = {
+  development: {
+    client: 'postgresql',
+    connection: config.postgres,
+  },
+  test: {
+    client: 'postgresql',
+    connection: {
+      database: process.env.TRAVIS ? "travis_ci_test" : "analytics_reporter_test",
+    },
+    migrations: {
+      tableName: 'knex_migrations',
+    },
+  },
+}

--- a/knexfile.js
+++ b/knexfile.js
@@ -8,7 +8,7 @@ module.exports = {
   test: {
     client: 'postgresql',
     connection: {
-      database: process.env.TRAVIS ? "travis_ci_test" : "analytics_reporter_test",
+      database: process.env.CIRCLECI ? "circle_test" : "analytics_reporter_test",
     },
     migrations: {
       tableName: 'knex_migrations',

--- a/migrations/20170308164751_create_analytics_data.js
+++ b/migrations/20170308164751_create_analytics_data.js
@@ -1,0 +1,14 @@
+exports.up = function(knex) {
+  return knex.schema.createTable("analytics_data", table => {
+    table.increments("id")
+    table.string("report_name")
+    table.string("report_agency")
+    table.dateTime("date_time")
+    table.jsonb("data")
+    table.timestamps(true, true)
+  })
+};
+
+exports.down = function(knex) {
+  return knex.schema.dropTable('analytics_data')
+};

--- a/migrations/20170316115145_add_analytics_data_indexes.js
+++ b/migrations/20170316115145_add_analytics_data_indexes.js
@@ -1,0 +1,14 @@
+exports.up = function(knex) {
+  return knex.schema.table("analytics_data", table => {
+    table.index(["report_name", "report_agency"])
+  }).then(() => {
+    return knex.schema.raw("CREATE INDEX analytics_data_date_time_desc ON analytics_data (date_time DESC NULLS LAST)")
+  })
+};
+
+exports.down = function(knex, Promise) {
+  return knex.schema.table("analytics_data", table => {
+    table.dropIndex(["report_name", "report_agency"])
+    table.dropIndex("date_time", "analytics_data_date_time_desc")
+  })
+};

--- a/migrations/20170522094056_rename_date_time_to_date.js
+++ b/migrations/20170522094056_rename_date_time_to_date.js
@@ -1,0 +1,12 @@
+
+exports.up = function(knex, Promise) {
+  return knex.schema.raw("ALTER TABLE analytics_data RENAME COLUMN date_time TO date").then(() => {
+   return knex.schema.raw("ALTER TABLE analytics_data ALTER COLUMN date TYPE date")
+  })
+};
+
+exports.down = function(knex, Promise) {
+  return knex.schema.raw("ALTER TABLE analytics_data RENAME COLUMN date TO date_time").then(() => {
+   return knex.schema.raw("ALTER TABLE analytics_data ALTER COLUMN date_time TYPE timestamp with time zone")
+  })
+};

--- a/package.json
+++ b/package.json
@@ -9,6 +9,8 @@
   "homepage": "https://github.com/18F/analytics-reporter",
   "license": "CC0-1.0",
   "scripts": {
+    "migrate": "`npm bin`/knex migrate:latest",
+    "pretest": "NODE_ENV=test npm run migrate",
     "start": "node app.js",
     "test": "`npm bin`/mocha test/*.test.js test/**/*.test.js"
   },

--- a/test/support/database.js
+++ b/test/support/database.js
@@ -10,16 +10,7 @@ const connection = {
 
 const resetSchema = () => {
   const db = knex({ client: "pg", connection })
-  return db.schema.dropTableIfExists(ANALYTICS_DATA_TABLE_NAME).then(() => {
-    return db.schema.createTable(ANALYTICS_DATA_TABLE_NAME, (table) => {
-      table.increments("id")
-      table.string("report_name")
-      table.string("report_agency")
-      table.date("date")
-      table.jsonb("data")
-      table.timestamps(true, true)
-    })
-  })
+  return db("analytics_data").delete()
 }
 
 module.exports = { connection, resetSchema }


### PR DESCRIPTION
This commit adds a Docker Compose configuration that can be used to run the Analytics reporter as if it were running on cloud.gov. This PR also includes some scripts to aid in running the reporter in Docker, as well as some changes to the scripts in `deploy/` to make it a little more environment agnostic.

Closes #78