### PR TITLE
Add S3Publisher

### DIFF
--- a/src/publish/s3.js
+++ b/src/publish/s3.js
@@ -1,0 +1,43 @@
+const AWS = require("aws-sdk")
+const winston = require("winston-color")
+const zlib = require("zlib")
+const config = require("../config")
+
+const S3 = new AWS.S3()
+
+const publish = (results, { format }) => {
+  winston.debug("[" + results.name + "] Publishing to " + config.aws.bucket + "...")
+
+  return _compress(results).then(compressed => {
+    return S3.putObject({
+      Bucket: config.aws.bucket,
+      Key: config.aws.path + "/" + results.name + "." + format,
+      Body: compressed,
+      ContentType: _mime(format),
+      ContentEncoding: "gzip",
+      ACL: "public-read",
+      CacheControl: "max-age=" + (config.aws.cache || 0),
+    }).promise()
+  })
+}
+
+const _compress = (data) => {
+  return new Promise((resolve, reject) => {
+    zlib.gzip(data, (err, compressed) => {
+      if (err) {
+        reject(err)
+      } else {
+        resolve(compressed)
+      }
+    })
+  })
+}
+
+const _mime = (format) => {
+  return {
+    json: "application/json",
+    csv: "text/csv",
+  }[format]
+}
+
+module.exports = { publish }

--- a/test/publish/s3.test.js
+++ b/test/publish/s3.test.js
@@ -1,0 +1,115 @@
+const expect = require("chai").expect
+const proxyquire = require("proxyquire")
+const resultsFixture = require("../support/fixtures/results")
+
+const S3Mock = function() {}
+S3Mock.mockedPutObject = () => {}
+S3Mock.prototype.putObject = function() {
+  return S3Mock.mockedPutObject.apply(this, arguments)
+}
+
+const zlibMock = {}
+
+const S3Publisher = proxyquire("../../src/publish/s3", {
+  "aws-sdk": { S3: S3Mock },
+  "zlib": zlibMock,
+  "../config": {
+    aws: {
+      bucket: "test-bucket",
+      cache: 60,
+      path: "path/to/data"
+    },
+  },
+})
+
+describe("S3Publisher", () => {
+  let results
+
+  beforeEach(() => {
+    results = Object.assign({}, resultsFixture)
+    S3Mock.mockedPutObject = () => ({ promise: () => Promise.resolve() })
+    zlibMock.gzip = (data, cb) => cb(null, data)
+  })
+
+  it("should publish compressed JSON results to the S3 bucket", done => {
+    results.name = "test-report"
+
+    let s3PutObjectCalled = false
+    let gzipCalled = false
+
+    S3Mock.mockedPutObject = (options) => {
+      s3PutObjectCalled = true
+
+      expect(options.Key).to.equal("path/to/data/test-report.json")
+      expect(options.Bucket).to.equal("test-bucket")
+      expect(options.ContentType).to.equal("application/json")
+      expect(options.ContentEncoding).to.equal("gzip")
+      expect(options.ACL).to.equal("public-read")
+      expect(options.CacheControl).to.equal("max-age=60")
+      expect(options.Body).to.equal("compressed data")
+
+      return { promise: () => Promise.resolve() }
+    }
+    zlibMock.gzip = (data, cb) => {
+      gzipCalled = true
+      cb(null, "compressed data")
+    }
+
+    S3Publisher.publish(results, { format: "json" }).then(() => {
+      expect(s3PutObjectCalled).to.equal(true)
+      expect(gzipCalled).to.equal(true)
+      done()
+    }).catch(done)
+  })
+
+  it("should publish compressed CSV results to the S3 bucket", done => {
+    results.name = "test-report"
+
+    let s3PutObjectCalled = false
+    let gzipCalled = false
+
+    S3Mock.mockedPutObject = (options) => {
+      s3PutObjectCalled = true
+
+      expect(options.Key).to.equal("path/to/data/test-report.csv")
+      expect(options.Bucket).to.equal("test-bucket")
+      expect(options.ContentType).to.equal("text/csv")
+      expect(options.ContentEncoding).to.equal("gzip")
+      expect(options.ACL).to.equal("public-read")
+      expect(options.CacheControl).to.equal("max-age=60")
+      expect(options.Body).to.equal("compressed data")
+
+      return { promise: () => Promise.resolve() }
+    }
+    zlibMock.gzip = (data, cb) => {
+      gzipCalled = true
+      cb(null, "compressed data")
+    }
+
+    S3Publisher.publish(results, { format: "csv" }).then(() => {
+      expect(s3PutObjectCalled).to.equal(true)
+      expect(gzipCalled).to.equal(true)
+      done()
+    }).catch(done)
+  })
+
+  it("should reject if there is an error uploading the data", done => {
+    S3Mock.mockedPutObject = () => ({
+      promise: () => Promise.reject(new Error("test s3 error"))
+    })
+
+    S3Publisher.publish(results, { format: "json" }).catch(err => {
+      expect(err.message).to.equal("test s3 error")
+      done()
+    }).catch(done)
+  })
+
+  it("should reject if there is an error compressing the data", done => {
+    zlibMock.gzip = (data, cb) => cb(new Error("test zlib error"))
+
+    S3Publisher.publish(results, { format: "json" }).catch(err => {
+      expect(err.message).to.equal("test zlib error")
+      done()
+    }).catch(done)
+  })
+})


### PR DESCRIPTION
This commit adds a new service that handles compressing data and publishing it to S3. This is called the `S3Publisher` and it exposed a `publish` function which does the same thing the `publish` function in `index.js` did before I removed it in this commit.