### PR TITLE
Disable PostgresPublisher for realtime reports

### DIFF
--- a/deploy/daily.sh
+++ b/deploy/daily.sh
@@ -1,140 +1,140 @@
 #!/bin/bash
 
 # JSON and CSV versions
-$HOME/bin/analytics --publish --frequency=daily --slim --verbose #--write-to-database
+$HOME/bin/analytics --publish --frequency=daily --slim --verbose --write-to-database
 $HOME/bin/analytics --publish --frequency=daily --slim --verbose --csv
 
 # Department of Education
 source $HOME/deploy/envs/education.env
-$HOME/bin/analytics --publish --frequency=daily --slim --verbose #--write-to-database
+$HOME/bin/analytics --publish --frequency=daily --slim --verbose --write-to-database
 $HOME/bin/analytics --publish --frequency=daily --slim --verbose --csv
 
 # Department of Veterans Affairs
 source $HOME/deploy/envs/veterans-affairs.env
-$HOME/bin/analytics --publish --frequency=daily --slim --verbose #--write-to-database
+$HOME/bin/analytics --publish --frequency=daily --slim --verbose --write-to-database
 $HOME/bin/analytics --publish --frequency=daily --slim --verbose --csv
 
 # National Aeronautics and Space Administration
 source $HOME/deploy/envs/national-aeronautics-space-administration.env
-$HOME/bin/analytics --publish --frequency=daily --slim --verbose #--write-to-database
+$HOME/bin/analytics --publish --frequency=daily --slim --verbose --write-to-database
 $HOME/bin/analytics --publish --frequency=daily --slim --verbose --csv
 
 # Department of Justice
 source $HOME/deploy/envs/justice.env
-$HOME/bin/analytics --publish --frequency=daily --slim --verbose #--write-to-database
+$HOME/bin/analytics --publish --frequency=daily --slim --verbose --write-to-database
 $HOME/bin/analytics --publish --frequency=daily --slim --verbose --csv
 
 # Department of Commerce
 source $HOME/deploy/envs/commerce.env
-$HOME/bin/analytics --publish --frequency=daily --slim --verbose #--write-to-database
+$HOME/bin/analytics --publish --frequency=daily --slim --verbose --write-to-database
 $HOME/bin/analytics --publish --frequency=daily --slim --verbose --csv
 
 # Environmental Protection Agency
 source $HOME/deploy/envs/environmental-protection-agency.env
-$HOME/bin/analytics --publish --frequency=daily --slim --verbose #--write-to-database
+$HOME/bin/analytics --publish --frequency=daily --slim --verbose --write-to-database
 $HOME/bin/analytics --publish --frequency=daily --slim --verbose --csv
 
 # Small Business Administration
 source $HOME/deploy/envs/small-business-administration.env
-$HOME/bin/analytics --publish --frequency=daily --slim --verbose #--write-to-database
+$HOME/bin/analytics --publish --frequency=daily --slim --verbose --write-to-database
 $HOME/bin/analytics --publish --frequency=daily --slim --verbose --csv
 
 # Department of Energy
 source $HOME/deploy/envs/energy.env
-$HOME/bin/analytics --publish --frequency=daily --slim --verbose #--write-to-database
+$HOME/bin/analytics --publish --frequency=daily --slim --verbose --write-to-database
 $HOME/bin/analytics --publish --frequency=daily --slim --verbose --csv
 
 # Department of the Interior
 source $HOME/deploy/envs/interior.env
-$HOME/bin/analytics --publish --frequency=daily --slim --verbose #--write-to-database
+$HOME/bin/analytics --publish --frequency=daily --slim --verbose --write-to-database
 $HOME/bin/analytics --publish --frequency=daily --slim --verbose --csv
 
 # National Archives and Records Administration
 source $HOME/deploy/envs/national-archives-records-administration.env
-$HOME/bin/analytics --publish --frequency=daily --slim --verbose #--write-to-database
+$HOME/bin/analytics --publish --frequency=daily --slim --verbose --write-to-database
 $HOME/bin/analytics --publish --frequency=daily --slim --verbose --csv
 
 # Department of Agriculture
 source $HOME/deploy/envs/agriculture.env
-$HOME/bin/analytics --publish --frequency=daily --slim --verbose #--write-to-database
+$HOME/bin/analytics --publish --frequency=daily --slim --verbose --write-to-database
 $HOME/bin/analytics --publish --frequency=daily --slim --verbose --csv
 
 # Department of Defense
 source $HOME/deploy/envs/defense.env
-$HOME/bin/analytics --publish --frequency=daily --slim --verbose #--write-to-database
+$HOME/bin/analytics --publish --frequency=daily --slim --verbose --write-to-database
 $HOME/bin/analytics --publish --frequency=daily --slim --verbose --csv
 
 # Department of Health and Human Services
 source $HOME/deploy/envs/health-human-services.env
-$HOME/bin/analytics --publish --frequency=daily --slim --verbose #--write-to-database
+$HOME/bin/analytics --publish --frequency=daily --slim --verbose --write-to-database
 $HOME/bin/analytics --publish --frequency=daily --slim --verbose --csv
 
 # Department of Housing and Urban Development
 source $HOME/deploy/envs/housing-urban-development.env
-$HOME/bin/analytics --publish --frequency=daily --slim --verbose #--write-to-database
+$HOME/bin/analytics --publish --frequency=daily --slim --verbose --write-to-database
 $HOME/bin/analytics --publish --frequency=daily --slim --verbose --csv
 
 # Department of Homeland Security
 source $HOME/deploy/envs/homeland-security.env
-$HOME/bin/analytics --publish --frequency=daily --slim --verbose #--write-to-database
+$HOME/bin/analytics --publish --frequency=daily --slim --verbose --write-to-database
 $HOME/bin/analytics --publish --frequency=daily --slim --verbose --csv
 
 # Department of Labor
 source $HOME/deploy/envs/labor.env
-$HOME/bin/analytics --publish --frequency=daily --slim --verbose #--write-to-database
+$HOME/bin/analytics --publish --frequency=daily --slim --verbose --write-to-database
 $HOME/bin/analytics --publish --frequency=daily --slim --verbose --csv
 
 # Department of State
 source $HOME/deploy/envs/state.env
-$HOME/bin/analytics --publish --frequency=daily --slim --verbose #--write-to-database
+$HOME/bin/analytics --publish --frequency=daily --slim --verbose --write-to-database
 $HOME/bin/analytics --publish --frequency=daily --slim --verbose --csv
 
 # Department of Transportation
 source $HOME/deploy/envs/transportation.env
-$HOME/bin/analytics --publish --frequency=daily --slim --verbose #--write-to-database
+$HOME/bin/analytics --publish --frequency=daily --slim --verbose --write-to-database
 $HOME/bin/analytics --publish --frequency=daily --slim --verbose --csv
 
 # Department of the Treasury
 source $HOME/deploy/envs/treasury.env
-$HOME/bin/analytics --publish --frequency=daily --slim --verbose #--write-to-database
+$HOME/bin/analytics --publish --frequency=daily --slim --verbose --write-to-database
 $HOME/bin/analytics --publish --frequency=daily --slim --verbose --csv
 
 # Agency for International Development
 source $HOME/deploy/envs/agency-international-development.env
-$HOME/bin/analytics --publish --frequency=daily --slim --verbose #--write-to-database
+$HOME/bin/analytics --publish --frequency=daily --slim --verbose --write-to-database
 $HOME/bin/analytics --publish --frequency=daily --slim --verbose --csv
 
 # General Services Administration
 source $HOME/deploy/envs/general-services-administration.env
-$HOME/bin/analytics --publish --frequency=daily --slim --verbose #--write-to-database
+$HOME/bin/analytics --publish --frequency=daily --slim --verbose --write-to-database
 $HOME/bin/analytics --publish --frequency=daily --slim --verbose --csv
 
 # National Science Foundation
 source $HOME/deploy/envs/national-science-foundation.env
-$HOME/bin/analytics --publish --frequency=daily --slim --verbose #--write-to-database
+$HOME/bin/analytics --publish --frequency=daily --slim --verbose --write-to-database
 $HOME/bin/analytics --publish --frequency=daily --slim --verbose --csv
 
 # Nuclear Regulatory Commission
 source $HOME/deploy/envs/nuclear-regulatory-commission.env
-$HOME/bin/analytics --publish --frequency=daily --slim --verbose #--write-to-database
+$HOME/bin/analytics --publish --frequency=daily --slim --verbose --write-to-database
 $HOME/bin/analytics --publish --frequency=daily --slim --verbose --csv
 
 # Office of Personnel Management
 source $HOME/deploy/envs/office-personnel-management.env
-$HOME/bin/analytics --publish --frequency=daily --slim --verbose #--write-to-database
+$HOME/bin/analytics --publish --frequency=daily --slim --verbose --write-to-database
 $HOME/bin/analytics --publish --frequency=daily --slim --verbose --csv
 
 # Social Security Administration
 source $HOME/deploy/envs/social-security-administration.env
-$HOME/bin/analytics --publish --frequency=daily --slim --verbose #--write-to-database
+$HOME/bin/analytics --publish --frequency=daily --slim --verbose --write-to-database
 $HOME/bin/analytics --publish --frequency=daily --slim --verbose --csv
 
 # Postal Service
 source $HOME/deploy/envs/postal-service.env
-$HOME/bin/analytics --publish --frequency=daily --slim --verbose #--write-to-database
+$HOME/bin/analytics --publish --frequency=daily --slim --verbose --write-to-database
 $HOME/bin/analytics --publish --frequency=daily --slim --verbose --csv
 
 # Executive Office of the President
 source $HOME/deploy/envs/executive-office-president.env
-$HOME/bin/analytics --publish --frequency=daily --slim --verbose #--write-to-database
+$HOME/bin/analytics --publish --frequency=daily --slim --verbose --write-to-database
 $HOME/bin/analytics --publish --frequency=daily --slim --verbose --csv

--- a/deploy/hourly.sh
+++ b/deploy/hourly.sh
@@ -4,112 +4,112 @@ export PATH=$PATH:/usr/local/bin
 source $HOME/.bashrc
 
 # just the one awkward 'today' report
-$HOME/bin/analytics --publish --frequency=hourly --slim --verbose #--write-to-database
+$HOME/bin/analytics --publish --frequency=hourly --slim --verbose --write-to-database
 
 # Department of Education
 source $HOME/deploy/envs/education.env
-$HOME/bin/analytics --publish --frequency=hourly --slim --verbose #--write-to-database
+$HOME/bin/analytics --publish --frequency=hourly --slim --verbose --write-to-database
 
 # National Aeronautics and Space Administration
 source $HOME/deploy/envs/national-aeronautics-space-administration.env
-$HOME/bin/analytics --publish --frequency=hourly --slim --verbose #--write-to-database
+$HOME/bin/analytics --publish --frequency=hourly --slim --verbose --write-to-database
 
 # Department of Justice
 source $HOME/deploy/envs/justice.env
-$HOME/bin/analytics --publish --frequency=hourly --slim --verbose #--write-to-database
+$HOME/bin/analytics --publish --frequency=hourly --slim --verbose --write-to-database
 
 # Department of Veterans Affairs
 source $HOME/deploy/envs/veterans-affairs.env
-$HOME/bin/analytics --publish --frequency=hourly --slim --verbose #--write-to-database
+$HOME/bin/analytics --publish --frequency=hourly --slim --verbose --write-to-database
 
 # Department of Commerce
 source $HOME/deploy/envs/commerce.env
-$HOME/bin/analytics --publish --frequency=hourly --slim --verbose #--write-to-database
+$HOME/bin/analytics --publish --frequency=hourly --slim --verbose --write-to-database
 
 # Environmental Protection Agency
 source $HOME/deploy/envs/environmental-protection-agency.env
-$HOME/bin/analytics --publish --frequency=hourly --slim --verbose #--write-to-database
+$HOME/bin/analytics --publish --frequency=hourly --slim --verbose --write-to-database
 
 # Small Business Administration
 source $HOME/deploy/envs/small-business-administration.env
-$HOME/bin/analytics --publish --frequency=hourly --slim --verbose #--write-to-database
+$HOME/bin/analytics --publish --frequency=hourly --slim --verbose --write-to-database
 
 # Department of Energy
 source $HOME/deploy/envs/energy.env
-$HOME/bin/analytics --publish --frequency=hourly --slim --verbose #--write-to-database
+$HOME/bin/analytics --publish --frequency=hourly --slim --verbose --write-to-database
 
 # Department of the Interior
 source $HOME/deploy/envs/interior.env
-$HOME/bin/analytics --publish --frequency=hourly --slim --verbose #--write-to-database
+$HOME/bin/analytics --publish --frequency=hourly --slim --verbose --write-to-database
 
 # National Archives and Records Administration
 source $HOME/deploy/envs/national-archives-records-administration.env
-$HOME/bin/analytics --publish --frequency=hourly --slim --verbose #--write-to-database
+$HOME/bin/analytics --publish --frequency=hourly --slim --verbose --write-to-database
 
 # Department of Agriculture
 source $HOME/deploy/envs/agriculture.env
-$HOME/bin/analytics --publish --frequency=hourly --slim --verbose #--write-to-database
+$HOME/bin/analytics --publish --frequency=hourly --slim --verbose --write-to-database
 
 # Department of Defense
 source $HOME/deploy/envs/defense.env
-$HOME/bin/analytics --publish --frequency=hourly --slim --verbose #--write-to-database
+$HOME/bin/analytics --publish --frequency=hourly --slim --verbose --write-to-database
 
 # Department of Health and Human Services
 source $HOME/deploy/envs/health-human-services.env
-$HOME/bin/analytics --publish --frequency=hourly --slim --verbose #--write-to-database
+$HOME/bin/analytics --publish --frequency=hourly --slim --verbose --write-to-database
 
 # Department of Housing and Urban Development
 source $HOME/deploy/envs/housing-urban-development.env
-$HOME/bin/analytics --publish --frequency=hourly --slim --verbose #--write-to-database
+$HOME/bin/analytics --publish --frequency=hourly --slim --verbose --write-to-database
 
 # Department of Homeland Security
 source $HOME/deploy/envs/homeland-security.env
-$HOME/bin/analytics --publish --frequency=hourly --slim --verbose #--write-to-database
+$HOME/bin/analytics --publish --frequency=hourly --slim --verbose --write-to-database
 
 # Department of Labor
 source $HOME/deploy/envs/labor.env
-$HOME/bin/analytics --publish --frequency=hourly --slim --verbose #--write-to-database
+$HOME/bin/analytics --publish --frequency=hourly --slim --verbose --write-to-database
 
 # Department of State
 source $HOME/deploy/envs/state.env
-$HOME/bin/analytics --publish --frequency=hourly --slim --verbose #--write-to-database
+$HOME/bin/analytics --publish --frequency=hourly --slim --verbose --write-to-database
 
 # Department of Transportation
 source $HOME/deploy/envs/transportation.env
-$HOME/bin/analytics --publish --frequency=hourly --slim --verbose #--write-to-database
+$HOME/bin/analytics --publish --frequency=hourly --slim --verbose --write-to-database
 
 # Department of the Treasury
 source $HOME/deploy/envs/treasury.env
-$HOME/bin/analytics --publish --frequency=hourly --slim --verbose #--write-to-database
+$HOME/bin/analytics --publish --frequency=hourly --slim --verbose --write-to-database
 
 # Agency for International Development
 source $HOME/deploy/envs/agency-international-development.env
-$HOME/bin/analytics --publish --frequency=hourly --slim --verbose #--write-to-database
+$HOME/bin/analytics --publish --frequency=hourly --slim --verbose --write-to-database
 
 # General Services Administration
 source $HOME/deploy/envs/general-services-administration.env
-$HOME/bin/analytics --publish --frequency=hourly --slim --verbose #--write-to-database
+$HOME/bin/analytics --publish --frequency=hourly --slim --verbose --write-to-database
 
 # National Science Foundation
 source $HOME/deploy/envs/national-science-foundation.env
-$HOME/bin/analytics --publish --frequency=hourly --slim --verbose #--write-to-database
+$HOME/bin/analytics --publish --frequency=hourly --slim --verbose --write-to-database
 
 # Nuclear Regulatory Commission
 source $HOME/deploy/envs/nuclear-regulatory-commission.env
-$HOME/bin/analytics --publish --frequency=hourly --slim --verbose #--write-to-database
+$HOME/bin/analytics --publish --frequency=hourly --slim --verbose --write-to-database
 
 # Office of Personnel Management
 source $HOME/deploy/envs/office-personnel-management.env
-$HOME/bin/analytics --publish --frequency=hourly --slim --verbose #--write-to-database
+$HOME/bin/analytics --publish --frequency=hourly --slim --verbose --write-to-database
 
 # Social Security Administration
 source $HOME/deploy/envs/social-security-administration.env
-$HOME/bin/analytics --publish --frequency=hourly --slim --verbose #--write-to-database
+$HOME/bin/analytics --publish --frequency=hourly --slim --verbose --write-to-database
 
 # Postal Service
 source $HOME/deploy/envs/postal-service.env
-$HOME/bin/analytics --publish --frequency=hourly --slim --verbose #--write-to-database
+$HOME/bin/analytics --publish --frequency=hourly --slim --verbose --write-to-database
 
 # Executive Office of the President
 source $HOME/deploy/envs/executive-office-president.env
-$HOME/bin/analytics --publish --frequency=hourly --slim --verbose #--write-to-database
+$HOME/bin/analytics --publish --frequency=hourly --slim --verbose --write-to-database

--- a/deploy/realtime.sh
+++ b/deploy/realtime.sh
@@ -3,141 +3,141 @@
 export PATH=$PATH:/usr/local/bin
 source $HOME/.bashrc
 
-$HOME/bin/analytics --publish --frequency=realtime --slim --verbose #--write-to-database
+$HOME/bin/analytics --publish --frequency=realtime --slim --verbose --write-to-database
 # we want just one realtime report in CSV, hardcoded for now to save on API requests
 $HOME/bin/analytics --publish --only=all-pages-realtime --slim --verbose --csv
 
 # Department of Education
 source $HOME/deploy/envs/education.env
-$HOME/bin/analytics --publish --frequency=realtime --slim --verbose #--write-to-database
+$HOME/bin/analytics --publish --frequency=realtime --slim --verbose --write-to-database
 $HOME/bin/analytics --publish --only=all-pages-realtime --slim --verbose --csv
 
 # Department of Veterans Affairs
 source $HOME/deploy/envs/veterans-affairs.env
-$HOME/bin/analytics --publish --frequency=realtime --slim --verbose #--write-to-database
+$HOME/bin/analytics --publish --frequency=realtime --slim --verbose --write-to-database
 $HOME/bin/analytics --publish --only=all-pages-realtime --slim --verbose --csv
 
 # National Aeronautics and Space Administration
 source $HOME/deploy/envs/national-aeronautics-space-administration.env
-$HOME/bin/analytics --publish --frequency=realtime --slim --verbose #--write-to-database
+$HOME/bin/analytics --publish --frequency=realtime --slim --verbose --write-to-database
 $HOME/bin/analytics --publish --only=all-pages-realtime --slim --verbose --csv
 
 # Department of Justice
 source $HOME/deploy/envs/justice.env
-$HOME/bin/analytics --publish --frequency=realtime --slim --verbose #--write-to-database
+$HOME/bin/analytics --publish --frequency=realtime --slim --verbose --write-to-database
 $HOME/bin/analytics --publish --only=all-pages-realtime --slim --verbose --csv
 
 # Department of Commerce
 source $HOME/deploy/envs/commerce.env
-$HOME/bin/analytics --publish --frequency=realtime --slim --verbose #--write-to-database
+$HOME/bin/analytics --publish --frequency=realtime --slim --verbose --write-to-database
 $HOME/bin/analytics --publish --only=all-pages-realtime --slim --verbose --csv
 
 # Environmental Protection Agency
 source $HOME/deploy/envs/environmental-protection-agency.env
-$HOME/bin/analytics --publish --frequency=realtime --slim --verbose #--write-to-database
+$HOME/bin/analytics --publish --frequency=realtime --slim --verbose --write-to-database
 $HOME/bin/analytics --publish --only=all-pages-realtime --slim --verbose --csv
 
 # Small Business Administration
 source $HOME/deploy/envs/small-business-administration.env
-$HOME/bin/analytics --publish --frequency=realtime --slim --verbose #--write-to-database
+$HOME/bin/analytics --publish --frequency=realtime --slim --verbose --write-to-database
 $HOME/bin/analytics --publish --only=all-pages-realtime --slim --verbose --csv
 
 # Department of Energy
 source $HOME/deploy/envs/energy.env
-$HOME/bin/analytics --publish --frequency=realtime --slim --verbose #--write-to-database
+$HOME/bin/analytics --publish --frequency=realtime --slim --verbose --write-to-database
 $HOME/bin/analytics --publish --only=all-pages-realtime --slim --verbose --csv
 
 # Department of the Interior
 source $HOME/deploy/envs/interior.env
-$HOME/bin/analytics --publish --frequency=realtime --slim --verbose #--write-to-database
+$HOME/bin/analytics --publish --frequency=realtime --slim --verbose --write-to-database
 $HOME/bin/analytics --publish --only=all-pages-realtime --slim --verbose --csv
 
 # National Archives and Records Administration
 source $HOME/deploy/envs/national-archives-records-administration.env
-$HOME/bin/analytics --publish --frequency=realtime --slim --verbose #--write-to-database
+$HOME/bin/analytics --publish --frequency=realtime --slim --verbose --write-to-database
 $HOME/bin/analytics --publish --only=all-pages-realtime --slim --verbose --csv
 
 # Department of Agriculture
 source $HOME/deploy/envs/agriculture.env
-$HOME/bin/analytics --publish --frequency=realtime --slim --verbose #--write-to-database
+$HOME/bin/analytics --publish --frequency=realtime --slim --verbose --write-to-database
 $HOME/bin/analytics --publish --only=all-pages-realtime --slim --verbose --csv
 
 # Department of Defense
 source $HOME/deploy/envs/defense.env
-$HOME/bin/analytics --publish --frequency=realtime --slim --verbose #--write-to-database
+$HOME/bin/analytics --publish --frequency=realtime --slim --verbose --write-to-database
 $HOME/bin/analytics --publish --only=all-pages-realtime --slim --verbose --csv
 
 # Department of Health and Human Services
 source $HOME/deploy/envs/health-human-services.env
-$HOME/bin/analytics --publish --frequency=realtime --slim --verbose #--write-to-database
+$HOME/bin/analytics --publish --frequency=realtime --slim --verbose --write-to-database
 $HOME/bin/analytics --publish --only=all-pages-realtime --slim --verbose --csv
 
 # Department of Housing and Urban Development
 source $HOME/deploy/envs/housing-urban-development.env
-$HOME/bin/analytics --publish --frequency=realtime --slim --verbose #--write-to-database
+$HOME/bin/analytics --publish --frequency=realtime --slim --verbose --write-to-database
 $HOME/bin/analytics --publish --only=all-pages-realtime --slim --verbose --csv
 
 # Department of Homeland Security
 source $HOME/deploy/envs/homeland-security.env
-$HOME/bin/analytics --publish --frequency=realtime --slim --verbose #--write-to-database
+$HOME/bin/analytics --publish --frequency=realtime --slim --verbose --write-to-database
 $HOME/bin/analytics --publish --only=all-pages-realtime --slim --verbose --csv
 
 # Department of Labor
 source $HOME/deploy/envs/labor.env
-$HOME/bin/analytics --publish --frequency=realtime --slim --verbose #--write-to-database
+$HOME/bin/analytics --publish --frequency=realtime --slim --verbose --write-to-database
 $HOME/bin/analytics --publish --only=all-pages-realtime --slim --verbose --csv
 
 # Department of State
 source $HOME/deploy/envs/state.env
-$HOME/bin/analytics --publish --frequency=realtime --slim --verbose #--write-to-database
+$HOME/bin/analytics --publish --frequency=realtime --slim --verbose --write-to-database
 $HOME/bin/analytics --publish --only=all-pages-realtime --slim --verbose --csv
 
 # Department of Transportation
 source $HOME/deploy/envs/transportation.env
-$HOME/bin/analytics --publish --frequency=realtime --slim --verbose #--write-to-database
+$HOME/bin/analytics --publish --frequency=realtime --slim --verbose --write-to-database
 $HOME/bin/analytics --publish --only=all-pages-realtime --slim --verbose --csv
 
 # Department of the Treasury
 source $HOME/deploy/envs/treasury.env
-$HOME/bin/analytics --publish --frequency=realtime --slim --verbose #--write-to-database
+$HOME/bin/analytics --publish --frequency=realtime --slim --verbose --write-to-database
 $HOME/bin/analytics --publish --only=all-pages-realtime --slim --verbose --csv
 
 # Agency for International Development
 source $HOME/deploy/envs/agency-international-development.env
-$HOME/bin/analytics --publish --frequency=realtime --slim --verbose #--write-to-database
+$HOME/bin/analytics --publish --frequency=realtime --slim --verbose --write-to-database
 $HOME/bin/analytics --publish --only=all-pages-realtime --slim --verbose --csv
 
 # General Services Administration
 source $HOME/deploy/envs/general-services-administration.env
-$HOME/bin/analytics --publish --frequency=realtime --slim --verbose #--write-to-database
+$HOME/bin/analytics --publish --frequency=realtime --slim --verbose --write-to-database
 $HOME/bin/analytics --publish --only=all-pages-realtime --slim --verbose --csv
 
 # National Science Foundation
 source $HOME/deploy/envs/national-science-foundation.env
-$HOME/bin/analytics --publish --frequency=realtime --slim --verbose #--write-to-database
+$HOME/bin/analytics --publish --frequency=realtime --slim --verbose --write-to-database
 $HOME/bin/analytics --publish --only=all-pages-realtime --slim --verbose --csv
 
 # Nuclear Regulatory Commission
 source $HOME/deploy/envs/nuclear-regulatory-commission.env
-$HOME/bin/analytics --publish --frequency=realtime --slim --verbose #--write-to-database
+$HOME/bin/analytics --publish --frequency=realtime --slim --verbose --write-to-database
 $HOME/bin/analytics --publish --only=all-pages-realtime --slim --verbose --csv
 
 # Office of Personnel Management
 source $HOME/deploy/envs/office-personnel-management.env
-$HOME/bin/analytics --publish --frequency=realtime --slim --verbose #--write-to-database
+$HOME/bin/analytics --publish --frequency=realtime --slim --verbose --write-to-database
 $HOME/bin/analytics --publish --only=all-pages-realtime --slim --verbose --csv
 
 # Social Security Administration
 source $HOME/deploy/envs/social-security-administration.env
-$HOME/bin/analytics --publish --frequency=realtime --slim --verbose #--write-to-database
+$HOME/bin/analytics --publish --frequency=realtime --slim --verbose --write-to-database
 $HOME/bin/analytics --publish --only=all-pages-realtime --slim --verbose --csv
 
 # Postal Service
 source $HOME/deploy/envs/postal-service.env
-$HOME/bin/analytics --publish --frequency=realtime --slim --verbose #--write-to-database
+$HOME/bin/analytics --publish --frequency=realtime --slim --verbose --write-to-database
 $HOME/bin/analytics --publish --only=all-pages-realtime --slim --verbose --csv
 
 # Executive Office of the President
 source $HOME/deploy/envs/executive-office-president.env
-$HOME/bin/analytics --publish --frequency=realtime --slim --verbose #--write-to-database
+$HOME/bin/analytics --publish --frequency=realtime --slim --verbose --write-to-database
 $HOME/bin/analytics --publish --only=all-pages-realtime --slim --verbose --csv

--- a/index.js
+++ b/index.js
@@ -72,7 +72,7 @@ var run = function(options) {
         data.agency = config.account.agency_name
       }
 
-      if (options["write-to-database"]) {
+      if (options["write-to-database"] && !report.realtime) {
         return PostgresPublisher.publish(data, reportOptions).then(() => data)
       } else {
         return Promise.resolve(data)

--- a/test/publish/postgres.test.js
+++ b/test/publish/postgres.test.js
@@ -32,185 +32,151 @@ describe("PostgresPublisher", () => {
       }).catch(done)
     })
 
-    context("when the report is not realtime", () => {
-      it("should insert a record for each results.data element", done => {
-        results.name = "report-name"
-        results.data = [
-          {
-            date: "2017-02-11",
-            name: "abc",
-          },
-          {
-            date: "2017-02-12",
-            name: "def",
-          },
-        ]
+    it("should insert a record for each results.data element", done => {
+      results.name = "report-name"
+      results.data = [
+        {
+          date: "2017-02-11",
+          name: "abc",
+        },
+        {
+          date: "2017-02-12",
+          name: "def",
+        },
+      ]
 
-        PostgresPublisher.publish(results).then(() => {
-          return databaseClient(ANALYTICS_DATA_TABLE_NAME).orderBy("date_time", "asc").select()
-        }).then(rows => {
-          expect(rows).to.have.length(2)
-          rows.forEach((row, index) => {
-            const data = results.data[index]
-            expect(row.report_name).to.equal("report-name")
-            expect(row.data.name).to.equal(data.name)
-            expect(row.data.date).to.be.undefined
+      PostgresPublisher.publish(results).then(() => {
+        return databaseClient(ANALYTICS_DATA_TABLE_NAME).orderBy("date_time", "asc").select()
+      }).then(rows => {
+        expect(rows).to.have.length(2)
+        rows.forEach((row, index) => {
+          const data = results.data[index]
+          expect(row.report_name).to.equal("report-name")
+          expect(row.data.name).to.equal(data.name)
+          expect(row.data.date).to.be.undefined
 
-            const date = moment.tz(data.date, config.timezone).toDate()
-            expect(row.date_time.getTime()).to.equal(date.getTime())
-          })
-          done()
-        }).catch(done)
-      })
-
-      it("should use the ga:hour dimension in the date if it is present", done => {
-        results.data = [{
-          date: "2017-02-15",
-          hour: "12",
-        }]
-        const date = moment.tz("2017-02-15T12:00:00", config.timezone).toDate()
-
-        PostgresPublisher.publish(results).then(() => {
-          return databaseClient.select().table(ANALYTICS_DATA_TABLE_NAME)
-        }).then(rows => {
-          const row = rows[0]
+          const date = moment.tz(data.date, config.timezone).toDate()
           expect(row.date_time.getTime()).to.equal(date.getTime())
-          done()
-        }).catch(done)
-      })
-
-      it("should ignore reports that don't have a ga:date dimension", done => {
-        results.query = { dimensions: "ga:something,ga:somethingElse" }
-
-        PostgresPublisher.publish(results).then(() => {
-          return databaseClient.select().table(ANALYTICS_DATA_TABLE_NAME)
-        }).then(rows => {
-          expect(rows).to.have.length(0)
-          done()
-        }).catch(done)
-      })
-
-      it("should ignore data points that have already been inserted", done => {
-        firstResults = Object.assign({}, results)
-        secondResults = Object.assign({}, results)
-
-        firstResults.data = [
-          {
-            date: "2017-02-11",
-            visits: "123",
-            browser: "Chrome",
-          },
-          {
-            date: "2017-02-11",
-            visits: "456",
-            browser: "Safari"
-          },
-        ]
-        secondResults.data = [
-          {
-            date: "2017-02-11",
-            visits: "456",
-            browser: "Safari",
-          },
-          {
-            date: "2017-02-11",
-            visits: "789",
-            browser: "Internet Explorer"
-          },
-        ]
-
-        PostgresPublisher.publish(firstResults).then(() => {
-          return PostgresPublisher.publish(secondResults)
-        }).then(() => {
-          return databaseClient.select().table(ANALYTICS_DATA_TABLE_NAME)
-        }).then(rows => {
-          expect(rows).to.have.length(3)
-          done()
-        }).catch(done)
-      })
-
-      it("should overwrite existing data points if the number of visits or users has changed", done => {
-        firstResults = Object.assign({}, results)
-        secondResults = Object.assign({}, results)
-
-        firstResults.data = [
-          {
-            date: "2017-02-11",
-            visits: "100",
-            browser: "Safari",
-          },
-        ]
-        secondResults.data = [
-          {
-            date: "2017-02-11",
-            visits: "200",
-            browser: "Safari",
-          },
-        ]
-
-        PostgresPublisher.publish(firstResults).then(() => {
-          return PostgresPublisher.publish(secondResults)
-        }).then(() => {
-          return databaseClient.select().table(ANALYTICS_DATA_TABLE_NAME)
-        }).then(rows => {
-          expect(rows).to.have.length(1)
-          expect(rows[0].data.visits).to.equal("200")
-          done()
-        }).catch(done)
-      })
-
-      it("should not not insert a record if the date is invalid", done => {
-        results.data = [
-          {
-            date: "(other)",
-            visits: "123",
-          },
-          {
-            date: "2017-02-16",
-            visits: "456",
-          },
-        ]
-
-        PostgresPublisher.publish(results).then(() => {
-          return databaseClient.select().table(ANALYTICS_DATA_TABLE_NAME)
-        }).then(rows => {
-          expect(rows).to.have.length(1)
-          expect(rows[0].data.visits).to.equal("456")
-          done()
-        }).catch(done)
-      })
+        })
+        done()
+      }).catch(done)
     })
 
-    context("when the report is realtime", () => {
-      it("should insert a record for each results.data element with the current date", done => {
-        const currentDateTime = new Date()
+    it("should use the ga:hour dimension in the date if it is present", done => {
+      results.data = [{
+        date: "2017-02-15",
+        hour: "12",
+      }]
+      const date = moment.tz("2017-02-15T12:00:00", config.timezone).toDate()
 
-        results.name = "report-name"
-        results.data = [
-          {
-            "city": "Washington DC",
-            "active_visitors": 123,
-          },
-          {
-            "city": "Baton Rouge",
-            "active_visitors": 456,
-          }
-        ]
+      PostgresPublisher.publish(results).then(() => {
+        return databaseClient.select().table(ANALYTICS_DATA_TABLE_NAME)
+      }).then(rows => {
+        const row = rows[0]
+        expect(row.date_time.getTime()).to.equal(date.getTime())
+        done()
+      }).catch(done)
+    })
 
-        PostgresPublisher.publish(results, { realtime: true }).then(() => {
-          return databaseClient.select().table(ANALYTICS_DATA_TABLE_NAME)
-        }).then(rows => {
-          expect(rows).to.have.length(2)
-          rows.forEach((row, index) => {
-            const data = results.data[index]
-            expect(row.report_name).to.equal("report-name")
-            expect(row.date_time - currentDateTime).to.be.below(1000)
-            expect(row.data.city).to.equal(data.city)
-            expect(row.data.active_visitors).to.equal(data.active_visitors)
-          })
-          done()
-        }).catch(done)
-      })
+    it("should ignore reports that don't have a ga:date dimension", done => {
+      results.query = { dimensions: "ga:something,ga:somethingElse" }
+
+      PostgresPublisher.publish(results).then(() => {
+        return databaseClient.select().table(ANALYTICS_DATA_TABLE_NAME)
+      }).then(rows => {
+        expect(rows).to.have.length(0)
+        done()
+      }).catch(done)
+    })
+
+    it("should ignore data points that have already been inserted", done => {
+      firstResults = Object.assign({}, results)
+      secondResults = Object.assign({}, results)
+
+      firstResults.data = [
+        {
+          date: "2017-02-11",
+          visits: "123",
+          browser: "Chrome",
+        },
+        {
+          date: "2017-02-11",
+          visits: "456",
+          browser: "Safari"
+        },
+      ]
+      secondResults.data = [
+        {
+          date: "2017-02-11",
+          visits: "456",
+          browser: "Safari",
+        },
+        {
+          date: "2017-02-11",
+          visits: "789",
+          browser: "Internet Explorer"
+        },
+      ]
+
+      PostgresPublisher.publish(firstResults).then(() => {
+        return PostgresPublisher.publish(secondResults)
+      }).then(() => {
+        return databaseClient.select().table(ANALYTICS_DATA_TABLE_NAME)
+      }).then(rows => {
+        expect(rows).to.have.length(3)
+        done()
+      }).catch(done)
+    })
+
+    it("should overwrite existing data points if the number of visits or users has changed", done => {
+      firstResults = Object.assign({}, results)
+      secondResults = Object.assign({}, results)
+
+      firstResults.data = [
+        {
+          date: "2017-02-11",
+          visits: "100",
+          browser: "Safari",
+        },
+      ]
+      secondResults.data = [
+        {
+          date: "2017-02-11",
+          visits: "200",
+          browser: "Safari",
+        },
+      ]
+
+      PostgresPublisher.publish(firstResults).then(() => {
+        return PostgresPublisher.publish(secondResults)
+      }).then(() => {
+        return databaseClient.select().table(ANALYTICS_DATA_TABLE_NAME)
+      }).then(rows => {
+        expect(rows).to.have.length(1)
+        expect(rows[0].data.visits).to.equal("200")
+        done()
+      }).catch(done)
+    })
+
+    it("should not not insert a record if the date is invalid", done => {
+      results.data = [
+        {
+          date: "(other)",
+          visits: "123",
+        },
+        {
+          date: "2017-02-16",
+          visits: "456",
+        },
+      ]
+
+      PostgresPublisher.publish(results).then(() => {
+        return databaseClient.select().table(ANALYTICS_DATA_TABLE_NAME)
+      }).then(rows => {
+        expect(rows).to.have.length(1)
+        expect(rows[0].data.visits).to.equal("456")
+        done()
+      }).catch(done)
     })
   })
 })


### PR DESCRIPTION
The volume of realtime reports was causing issues for the API. The amount of data was causing queries to run for much longer than they should have. This commit prevents realtime reports from being written to the db. It also re-enables the `--write-to-database` option in the deploy scripts.