### PR TITLE
Add DiskPublisher

### DIFF
--- a/index.js
+++ b/index.js
@@ -5,6 +5,7 @@ const winston = require("winston-color")
 
 const config = require("./src/config")
 const Analytics = require("./src/analytics")
+const DiskPublisher = require("./src/publish/disk")
 const PostgresPublisher = require("./src/publish/postgres")
 const ResultFormatter = require("./src/process-results/result-formatter")
 const S3Publisher = require("./src/publish/s3")
@@ -45,7 +46,7 @@ const _publishReport = (report, formattedResult, options) => {
   if (options.publish) {
     return S3Publisher.publish(report, formattedResult, options)
   } else if (options.output && typeof(options.output) === "string") {
-    return _writeReportToDisk(report, formattedResult, options)
+    return DiskPublisher.publish(report, formattedResult, options)
   } else {
     console.log(formattedResult)
   }
@@ -76,18 +77,6 @@ const _writeReportToDatabase = (report, result, options) => {
   } else {
     return Promise.resolve(result)
   }
-}
-
-const _writeReportToDisk = (report, formattedResult, options) => {
-  return new Promise((resolve, reject) => {
-    fs.writeFile(path.join(options.output, `${report.name}.${options.format}`), formattedResult, err => {
-      if (err) {
-        reject(err)
-      } else {
-        resolve()
-      }
-    })
-  })
 }
 
 module.exports = { run };

--- a/src/publish/disk.js
+++ b/src/publish/disk.js
@@ -1,0 +1,19 @@
+const fs = require("fs")
+const path = require("path")
+
+const publish = (report, results, { output, format }) => {
+  const filename = `${report.name}.${format}`
+  const filepath = path.join(output, filename)
+
+  return new Promise((resolve, reject) => {
+    fs.writeFile(filepath, results, err => {
+      if (err) {
+        reject(err)
+      } else {
+        resolve()
+      }
+    })
+  })
+}
+
+module.exports = { publish }

--- a/test/publish/disk.test.js
+++ b/test/publish/disk.test.js
@@ -1,0 +1,58 @@
+const expect = require("chai").expect
+const proxyquire = require("proxyquire")
+
+describe("DiskPublisher", () => {
+  let DiskPublisher
+  let fs = {}
+
+  beforeEach(() => {
+    fs = { writeFile: (path, contents, cb) => cb() }
+    DiskPublisher = proxyquire("../../src/publish/disk", {
+      fs: fs,
+    })
+  })
+
+  describe(".publish(report, results, options)", () => {
+    context("when the format is json", () => {
+      it("should write the results to <output>/<report name>.json", done => {
+        const options = { output: "path/to/output", format: "json" }
+        const report = { name: "report-name" }
+        const results = "I'm the results"
+
+        let fileWritten = false
+        fs.writeFile = (path, contents, cb) => {
+          expect(path).to.equal("path/to/output/report-name.json")
+          expect(contents).to.equal("I'm the results")
+          fileWritten = true
+          cb(null)
+        }
+
+        DiskPublisher.publish(report, results, options).then(() => {
+          expect(fileWritten).to.be.true
+          done()
+        }).catch(done)
+      })
+    })
+
+    context("when the format is csv", () => {
+      it("should write the results to <output>/<report name>.csv", done => {
+        const options = { output: "path/to/output", format: "csv" }
+        const report = { name: "report-name" }
+        const results = "I'm the results"
+
+        let fileWritten = false
+        fs.writeFile = (path, contents, cb) => {
+          expect(path).to.equal("path/to/output/report-name.csv")
+          expect(contents).to.equal("I'm the results")
+          fileWritten = true
+          cb(null)
+        }
+
+        DiskPublisher.publish(report, results, options).then(() => {
+          expect(fileWritten).to.be.true
+          done()
+        }).catch(done)
+      })
+    })
+  })
+})


### PR DESCRIPTION
This commit moves the code that writes reports to disk out of `index.js` and into a new Service named `DiskPublisher`. This is only invoked when the `--output` option is present.