### PR TITLE
Add dockerignore

### DIFF
--- a/.dockerignore
+++ b/.dockerignore
@@ -1,0 +1,1 @@
+.gitignore

--- a/.gitignore
+++ b/.gitignore
@@ -12,3 +12,7 @@ key_file.txt
 todo.txt
 npm-debug.log
 *.swp
+
+# Track selected JSON files
+!package.json
+!reports/*.json


### PR DESCRIPTION
This commit adds a dockerignore file. This file is there to prevent secrets in our local copies from being wrapped up in docker images that may get pushed to the Docker Hub.
    
The dockerignore is symlinked to the gitignore to make sure that any changes to the gitignore get carried over. As such, the gitignore needed to be modified to let selected JSON files be added.