### PR TITLE
Add separate API report that runs daily

### DIFF
--- a/deploy/api.sh
+++ b/deploy/api.sh
@@ -1,0 +1,114 @@
+#!/bin/bash
+
+export ANALYTICS_REPORTS_PATH=reports/api.json
+
+# Gov Wide
+$HOME/bin/analytics --verbose --write-to-database --output /tmp
+
+# Department of Education
+source $HOME/deploy/envs/education.env
+$HOME/bin/analytics --verbose --write-to-database --output /tmp/education
+
+# Department of Veterans Affairs
+source $HOME/deploy/envs/veterans-affairs.env
+$HOME/bin/analytics --verbose --write-to-database --output /tmp/veterans-affairs
+
+# National Aeronautics and Space Administration
+source $HOME/deploy/envs/national-aeronautics-space-administration.env
+$HOME/bin/analytics --verbose --write-to-database --output /tmp/national-aeronautics-space-administration
+
+# Department of Justice
+source $HOME/deploy/envs/justice.env
+$HOME/bin/analytics --verbose --write-to-database --output /tmp/justice
+
+# Department of Commerce
+source $HOME/deploy/envs/commerce.env
+$HOME/bin/analytics --verbose --write-to-database --output /tmp/commerce
+
+# Environmental Protection Agency
+source $HOME/deploy/envs/environmental-protection-agency.env
+$HOME/bin/analytics --verbose --write-to-database --output /tmp/environmental-protection-agency
+
+# Small Business Administration
+source $HOME/deploy/envs/small-business-administration.env
+$HOME/bin/analytics --verbose --write-to-database --output /tmp/small-business-administration
+
+# Department of Energy
+source $HOME/deploy/envs/energy.env
+$HOME/bin/analytics --verbose --write-to-database --output /tmp/energy
+
+# Department of the Interior
+source $HOME/deploy/envs/interior.env
+$HOME/bin/analytics --verbose --write-to-database --output /tmp/interior
+
+# National Archives and Records Administration
+source $HOME/deploy/envs/national-archives-records-administration.env
+$HOME/bin/analytics --verbose --write-to-database --output /tmp/national-archives-records-administration
+
+# Department of Agriculture
+source $HOME/deploy/envs/agriculture.env
+$HOME/bin/analytics --verbose --write-to-database --output /tmp/agriculture
+
+# Department of Defense
+source $HOME/deploy/envs/defense.env
+$HOME/bin/analytics --verbose --write-to-database --output /tmp/defense
+
+# Department of Health and Human Services
+source $HOME/deploy/envs/health-human-services.env
+$HOME/bin/analytics --verbose --write-to-database --output /tmp/health-human-services
+
+# Department of Housing and Urban Development
+source $HOME/deploy/envs/housing-urban-development.env
+$HOME/bin/analytics --verbose --write-to-database --output /tmp/housing-urban-development
+
+# Department of Homeland Security
+source $HOME/deploy/envs/homeland-security.env
+$HOME/bin/analytics --verbose --write-to-database --output /tmp/homeland-security
+
+# Department of Labor
+source $HOME/deploy/envs/labor.env
+$HOME/bin/analytics --verbose --write-to-database --output /tmp/labor
+
+# Department of State
+source $HOME/deploy/envs/state.env
+$HOME/bin/analytics --verbose --write-to-database --output /tmp/state
+
+# Department of Transportation
+source $HOME/deploy/envs/transportation.env
+$HOME/bin/analytics --verbose --write-to-database --output /tmp/transportation
+
+# Department of the Treasury
+source $HOME/deploy/envs/treasury.env
+$HOME/bin/analytics --verbose --write-to-database --output /tmp/treasury
+
+# Agency for International Development
+source $HOME/deploy/envs/agency-international-development.env
+$HOME/bin/analytics --verbose --write-to-database --output /tmp/agency-international-development
+
+# General Services Administration
+source $HOME/deploy/envs/general-services-administration.env
+$HOME/bin/analytics --verbose --write-to-database --output /tmp/general-services-administration
+
+# National Science Foundation
+source $HOME/deploy/envs/national-science-foundation.env
+$HOME/bin/analytics --verbose --write-to-database --output /tmp/national-science-foundation
+
+# Nuclear Regulatory Commission
+source $HOME/deploy/envs/nuclear-regulatory-commission.env
+$HOME/bin/analytics --verbose --write-to-database --output /tmp/nuclear-regulatory-commission
+
+# Office of Personnel Management
+source $HOME/deploy/envs/office-personnel-management.env
+$HOME/bin/analytics --verbose --write-to-database --output /tmp/office-personnel-management
+
+# Social Security Administration
+source $HOME/deploy/envs/social-security-administration.env
+$HOME/bin/analytics --verbose --write-to-database --output /tmp/social-security-administration
+
+# Postal Service
+source $HOME/deploy/envs/postal-service.env
+$HOME/bin/analytics --verbose --write-to-database --output /tmp/postal-service
+
+# Executive Office of the President
+source $HOME/deploy/envs/executive-office-president.env
+$HOME/bin/analytics --verbose --write-to-database --output /tmp/executive-office-president

--- a/deploy/cron.js
+++ b/deploy/cron.js
@@ -10,6 +10,21 @@ if (process.env.NEW_RELIC_APP_NAME) {
 const spawn = require("child_process").exec;
 const execSync = require("child_process").execSync;
 
+var api_run = function() {
+	winston.info("about to run api.sh");
+
+	var api = spawn("./deploy/api.sh")
+	api.stdout.on("data", (data) => {
+		winston.info("[api.sh]", data)
+	})
+	api.stderr.on("data", (data) => {
+		winston.info("[api.sh]", data)
+	})
+	api.on("exit", (code) => {
+		winston.info("api.sh exitted with code:", code)
+	})
+}
+
 var daily_run = function() {
 	winston.info("about to run daily.sh");
 
@@ -57,9 +72,12 @@ var realtime_run = function(){
 
 
 winston.info("starting cron.js!");
+api_run();
 daily_run();
 hourly_run();
 realtime_run();
+//api
+setInterval(api_run,1000 * 60 * 24)
 //daily
 const currentTime = new Date();
 const nextRunTime = new Date(

--- a/deploy/daily.sh
+++ b/deploy/daily.sh
@@ -1,140 +1,140 @@
 #!/bin/bash
 
 # JSON and CSV versions
-$HOME/bin/analytics --publish --frequency=daily --slim --verbose --write-to-database
+$HOME/bin/analytics --publish --frequency=daily --slim --verbose
 $HOME/bin/analytics --publish --frequency=daily --slim --verbose --csv
 
 # Department of Education
 source $HOME/deploy/envs/education.env
-$HOME/bin/analytics --publish --frequency=daily --slim --verbose --write-to-database
+$HOME/bin/analytics --publish --frequency=daily --slim --verbose
 $HOME/bin/analytics --publish --frequency=daily --slim --verbose --csv
 
 # Department of Veterans Affairs
 source $HOME/deploy/envs/veterans-affairs.env
-$HOME/bin/analytics --publish --frequency=daily --slim --verbose --write-to-database
+$HOME/bin/analytics --publish --frequency=daily --slim --verbose
 $HOME/bin/analytics --publish --frequency=daily --slim --verbose --csv
 
 # National Aeronautics and Space Administration
 source $HOME/deploy/envs/national-aeronautics-space-administration.env
-$HOME/bin/analytics --publish --frequency=daily --slim --verbose --write-to-database
+$HOME/bin/analytics --publish --frequency=daily --slim --verbose
 $HOME/bin/analytics --publish --frequency=daily --slim --verbose --csv
 
 # Department of Justice
 source $HOME/deploy/envs/justice.env
-$HOME/bin/analytics --publish --frequency=daily --slim --verbose --write-to-database
+$HOME/bin/analytics --publish --frequency=daily --slim --verbose
 $HOME/bin/analytics --publish --frequency=daily --slim --verbose --csv
 
 # Department of Commerce
 source $HOME/deploy/envs/commerce.env
-$HOME/bin/analytics --publish --frequency=daily --slim --verbose --write-to-database
+$HOME/bin/analytics --publish --frequency=daily --slim --verbose
 $HOME/bin/analytics --publish --frequency=daily --slim --verbose --csv
 
 # Environmental Protection Agency
 source $HOME/deploy/envs/environmental-protection-agency.env
-$HOME/bin/analytics --publish --frequency=daily --slim --verbose --write-to-database
+$HOME/bin/analytics --publish --frequency=daily --slim --verbose
 $HOME/bin/analytics --publish --frequency=daily --slim --verbose --csv
 
 # Small Business Administration
 source $HOME/deploy/envs/small-business-administration.env
-$HOME/bin/analytics --publish --frequency=daily --slim --verbose --write-to-database
+$HOME/bin/analytics --publish --frequency=daily --slim --verbose
 $HOME/bin/analytics --publish --frequency=daily --slim --verbose --csv
 
 # Department of Energy
 source $HOME/deploy/envs/energy.env
-$HOME/bin/analytics --publish --frequency=daily --slim --verbose --write-to-database
+$HOME/bin/analytics --publish --frequency=daily --slim --verbose
 $HOME/bin/analytics --publish --frequency=daily --slim --verbose --csv
 
 # Department of the Interior
 source $HOME/deploy/envs/interior.env
-$HOME/bin/analytics --publish --frequency=daily --slim --verbose --write-to-database
+$HOME/bin/analytics --publish --frequency=daily --slim --verbose
 $HOME/bin/analytics --publish --frequency=daily --slim --verbose --csv
 
 # National Archives and Records Administration
 source $HOME/deploy/envs/national-archives-records-administration.env
-$HOME/bin/analytics --publish --frequency=daily --slim --verbose --write-to-database
+$HOME/bin/analytics --publish --frequency=daily --slim --verbose
 $HOME/bin/analytics --publish --frequency=daily --slim --verbose --csv
 
 # Department of Agriculture
 source $HOME/deploy/envs/agriculture.env
-$HOME/bin/analytics --publish --frequency=daily --slim --verbose --write-to-database
+$HOME/bin/analytics --publish --frequency=daily --slim --verbose
 $HOME/bin/analytics --publish --frequency=daily --slim --verbose --csv
 
 # Department of Defense
 source $HOME/deploy/envs/defense.env
-$HOME/bin/analytics --publish --frequency=daily --slim --verbose --write-to-database
+$HOME/bin/analytics --publish --frequency=daily --slim --verbose
 $HOME/bin/analytics --publish --frequency=daily --slim --verbose --csv
 
 # Department of Health and Human Services
 source $HOME/deploy/envs/health-human-services.env
-$HOME/bin/analytics --publish --frequency=daily --slim --verbose --write-to-database
+$HOME/bin/analytics --publish --frequency=daily --slim --verbose
 $HOME/bin/analytics --publish --frequency=daily --slim --verbose --csv
 
 # Department of Housing and Urban Development
 source $HOME/deploy/envs/housing-urban-development.env
-$HOME/bin/analytics --publish --frequency=daily --slim --verbose --write-to-database
+$HOME/bin/analytics --publish --frequency=daily --slim --verbose
 $HOME/bin/analytics --publish --frequency=daily --slim --verbose --csv
 
 # Department of Homeland Security
 source $HOME/deploy/envs/homeland-security.env
-$HOME/bin/analytics --publish --frequency=daily --slim --verbose --write-to-database
+$HOME/bin/analytics --publish --frequency=daily --slim --verbose
 $HOME/bin/analytics --publish --frequency=daily --slim --verbose --csv
 
 # Department of Labor
 source $HOME/deploy/envs/labor.env
-$HOME/bin/analytics --publish --frequency=daily --slim --verbose --write-to-database
+$HOME/bin/analytics --publish --frequency=daily --slim --verbose
 $HOME/bin/analytics --publish --frequency=daily --slim --verbose --csv
 
 # Department of State
 source $HOME/deploy/envs/state.env
-$HOME/bin/analytics --publish --frequency=daily --slim --verbose --write-to-database
+$HOME/bin/analytics --publish --frequency=daily --slim --verbose
 $HOME/bin/analytics --publish --frequency=daily --slim --verbose --csv
 
 # Department of Transportation
 source $HOME/deploy/envs/transportation.env
-$HOME/bin/analytics --publish --frequency=daily --slim --verbose --write-to-database
+$HOME/bin/analytics --publish --frequency=daily --slim --verbose
 $HOME/bin/analytics --publish --frequency=daily --slim --verbose --csv
 
 # Department of the Treasury
 source $HOME/deploy/envs/treasury.env
-$HOME/bin/analytics --publish --frequency=daily --slim --verbose --write-to-database
+$HOME/bin/analytics --publish --frequency=daily --slim --verbose
 $HOME/bin/analytics --publish --frequency=daily --slim --verbose --csv
 
 # Agency for International Development
 source $HOME/deploy/envs/agency-international-development.env
-$HOME/bin/analytics --publish --frequency=daily --slim --verbose --write-to-database
+$HOME/bin/analytics --publish --frequency=daily --slim --verbose
 $HOME/bin/analytics --publish --frequency=daily --slim --verbose --csv
 
 # General Services Administration
 source $HOME/deploy/envs/general-services-administration.env
-$HOME/bin/analytics --publish --frequency=daily --slim --verbose --write-to-database
+$HOME/bin/analytics --publish --frequency=daily --slim --verbose
 $HOME/bin/analytics --publish --frequency=daily --slim --verbose --csv
 
 # National Science Foundation
 source $HOME/deploy/envs/national-science-foundation.env
-$HOME/bin/analytics --publish --frequency=daily --slim --verbose --write-to-database
+$HOME/bin/analytics --publish --frequency=daily --slim --verbose
 $HOME/bin/analytics --publish --frequency=daily --slim --verbose --csv
 
 # Nuclear Regulatory Commission
 source $HOME/deploy/envs/nuclear-regulatory-commission.env
-$HOME/bin/analytics --publish --frequency=daily --slim --verbose --write-to-database
+$HOME/bin/analytics --publish --frequency=daily --slim --verbose
 $HOME/bin/analytics --publish --frequency=daily --slim --verbose --csv
 
 # Office of Personnel Management
 source $HOME/deploy/envs/office-personnel-management.env
-$HOME/bin/analytics --publish --frequency=daily --slim --verbose --write-to-database
+$HOME/bin/analytics --publish --frequency=daily --slim --verbose
 $HOME/bin/analytics --publish --frequency=daily --slim --verbose --csv
 
 # Social Security Administration
 source $HOME/deploy/envs/social-security-administration.env
-$HOME/bin/analytics --publish --frequency=daily --slim --verbose --write-to-database
+$HOME/bin/analytics --publish --frequency=daily --slim --verbose
 $HOME/bin/analytics --publish --frequency=daily --slim --verbose --csv
 
 # Postal Service
 source $HOME/deploy/envs/postal-service.env
-$HOME/bin/analytics --publish --frequency=daily --slim --verbose --write-to-database
+$HOME/bin/analytics --publish --frequency=daily --slim --verbose
 $HOME/bin/analytics --publish --frequency=daily --slim --verbose --csv
 
 # Executive Office of the President
 source $HOME/deploy/envs/executive-office-president.env
-$HOME/bin/analytics --publish --frequency=daily --slim --verbose --write-to-database
+$HOME/bin/analytics --publish --frequency=daily --slim --verbose
 $HOME/bin/analytics --publish --frequency=daily --slim --verbose --csv

--- a/deploy/hourly.sh
+++ b/deploy/hourly.sh
@@ -4,112 +4,112 @@ export PATH=$PATH:/usr/local/bin
 source $HOME/.bashrc
 
 # just the one awkward 'today' report
-$HOME/bin/analytics --publish --frequency=hourly --slim --verbose --write-to-database
+$HOME/bin/analytics --publish --frequency=hourly --slim --verbose
 
 # Department of Education
 source $HOME/deploy/envs/education.env
-$HOME/bin/analytics --publish --frequency=hourly --slim --verbose --write-to-database
+$HOME/bin/analytics --publish --frequency=hourly --slim --verbose
 
 # National Aeronautics and Space Administration
 source $HOME/deploy/envs/national-aeronautics-space-administration.env
-$HOME/bin/analytics --publish --frequency=hourly --slim --verbose --write-to-database
+$HOME/bin/analytics --publish --frequency=hourly --slim --verbose
 
 # Department of Justice
 source $HOME/deploy/envs/justice.env
-$HOME/bin/analytics --publish --frequency=hourly --slim --verbose --write-to-database
+$HOME/bin/analytics --publish --frequency=hourly --slim --verbose
 
 # Department of Veterans Affairs
 source $HOME/deploy/envs/veterans-affairs.env
-$HOME/bin/analytics --publish --frequency=hourly --slim --verbose --write-to-database
+$HOME/bin/analytics --publish --frequency=hourly --slim --verbose
 
 # Department of Commerce
 source $HOME/deploy/envs/commerce.env
-$HOME/bin/analytics --publish --frequency=hourly --slim --verbose --write-to-database
+$HOME/bin/analytics --publish --frequency=hourly --slim --verbose
 
 # Environmental Protection Agency
 source $HOME/deploy/envs/environmental-protection-agency.env
-$HOME/bin/analytics --publish --frequency=hourly --slim --verbose --write-to-database
+$HOME/bin/analytics --publish --frequency=hourly --slim --verbose
 
 # Small Business Administration
 source $HOME/deploy/envs/small-business-administration.env
-$HOME/bin/analytics --publish --frequency=hourly --slim --verbose --write-to-database
+$HOME/bin/analytics --publish --frequency=hourly --slim --verbose
 
 # Department of Energy
 source $HOME/deploy/envs/energy.env
-$HOME/bin/analytics --publish --frequency=hourly --slim --verbose --write-to-database
+$HOME/bin/analytics --publish --frequency=hourly --slim --verbose
 
 # Department of the Interior
 source $HOME/deploy/envs/interior.env
-$HOME/bin/analytics --publish --frequency=hourly --slim --verbose --write-to-database
+$HOME/bin/analytics --publish --frequency=hourly --slim --verbose
 
 # National Archives and Records Administration
 source $HOME/deploy/envs/national-archives-records-administration.env
-$HOME/bin/analytics --publish --frequency=hourly --slim --verbose --write-to-database
+$HOME/bin/analytics --publish --frequency=hourly --slim --verbose
 
 # Department of Agriculture
 source $HOME/deploy/envs/agriculture.env
-$HOME/bin/analytics --publish --frequency=hourly --slim --verbose --write-to-database
+$HOME/bin/analytics --publish --frequency=hourly --slim --verbose
 
 # Department of Defense
 source $HOME/deploy/envs/defense.env
-$HOME/bin/analytics --publish --frequency=hourly --slim --verbose --write-to-database
+$HOME/bin/analytics --publish --frequency=hourly --slim --verbose
 
 # Department of Health and Human Services
 source $HOME/deploy/envs/health-human-services.env
-$HOME/bin/analytics --publish --frequency=hourly --slim --verbose --write-to-database
+$HOME/bin/analytics --publish --frequency=hourly --slim --verbose
 
 # Department of Housing and Urban Development
 source $HOME/deploy/envs/housing-urban-development.env
-$HOME/bin/analytics --publish --frequency=hourly --slim --verbose --write-to-database
+$HOME/bin/analytics --publish --frequency=hourly --slim --verbose
 
 # Department of Homeland Security
 source $HOME/deploy/envs/homeland-security.env
-$HOME/bin/analytics --publish --frequency=hourly --slim --verbose --write-to-database
+$HOME/bin/analytics --publish --frequency=hourly --slim --verbose
 
 # Department of Labor
 source $HOME/deploy/envs/labor.env
-$HOME/bin/analytics --publish --frequency=hourly --slim --verbose --write-to-database
+$HOME/bin/analytics --publish --frequency=hourly --slim --verbose
 
 # Department of State
 source $HOME/deploy/envs/state.env
-$HOME/bin/analytics --publish --frequency=hourly --slim --verbose --write-to-database
+$HOME/bin/analytics --publish --frequency=hourly --slim --verbose
 
 # Department of Transportation
 source $HOME/deploy/envs/transportation.env
-$HOME/bin/analytics --publish --frequency=hourly --slim --verbose --write-to-database
+$HOME/bin/analytics --publish --frequency=hourly --slim --verbose
 
 # Department of the Treasury
 source $HOME/deploy/envs/treasury.env
-$HOME/bin/analytics --publish --frequency=hourly --slim --verbose --write-to-database
+$HOME/bin/analytics --publish --frequency=hourly --slim --verbose
 
 # Agency for International Development
 source $HOME/deploy/envs/agency-international-development.env
-$HOME/bin/analytics --publish --frequency=hourly --slim --verbose --write-to-database
+$HOME/bin/analytics --publish --frequency=hourly --slim --verbose
 
 # General Services Administration
 source $HOME/deploy/envs/general-services-administration.env
-$HOME/bin/analytics --publish --frequency=hourly --slim --verbose --write-to-database
+$HOME/bin/analytics --publish --frequency=hourly --slim --verbose
 
 # National Science Foundation
 source $HOME/deploy/envs/national-science-foundation.env
-$HOME/bin/analytics --publish --frequency=hourly --slim --verbose --write-to-database
+$HOME/bin/analytics --publish --frequency=hourly --slim --verbose
 
 # Nuclear Regulatory Commission
 source $HOME/deploy/envs/nuclear-regulatory-commission.env
-$HOME/bin/analytics --publish --frequency=hourly --slim --verbose --write-to-database
+$HOME/bin/analytics --publish --frequency=hourly --slim --verbose
 
 # Office of Personnel Management
 source $HOME/deploy/envs/office-personnel-management.env
-$HOME/bin/analytics --publish --frequency=hourly --slim --verbose --write-to-database
+$HOME/bin/analytics --publish --frequency=hourly --slim --verbose
 
 # Social Security Administration
 source $HOME/deploy/envs/social-security-administration.env
-$HOME/bin/analytics --publish --frequency=hourly --slim --verbose --write-to-database
+$HOME/bin/analytics --publish --frequency=hourly --slim --verbose
 
 # Postal Service
 source $HOME/deploy/envs/postal-service.env
-$HOME/bin/analytics --publish --frequency=hourly --slim --verbose --write-to-database
+$HOME/bin/analytics --publish --frequency=hourly --slim --verbose
 
 # Executive Office of the President
 source $HOME/deploy/envs/executive-office-president.env
-$HOME/bin/analytics --publish --frequency=hourly --slim --verbose --write-to-database
+$HOME/bin/analytics --publish --frequency=hourly --slim --verbose

--- a/deploy/realtime.sh
+++ b/deploy/realtime.sh
@@ -3,141 +3,141 @@
 export PATH=$PATH:/usr/local/bin
 source $HOME/.bashrc
 
-$HOME/bin/analytics --publish --frequency=realtime --slim --verbose --write-to-database
+$HOME/bin/analytics --publish --frequency=realtime --slim --verbose
 # we want just one realtime report in CSV, hardcoded for now to save on API requests
 $HOME/bin/analytics --publish --only=all-pages-realtime --slim --verbose --csv
 
 # Department of Education
 source $HOME/deploy/envs/education.env
-$HOME/bin/analytics --publish --frequency=realtime --slim --verbose --write-to-database
+$HOME/bin/analytics --publish --frequency=realtime --slim --verbose
 $HOME/bin/analytics --publish --only=all-pages-realtime --slim --verbose --csv
 
 # Department of Veterans Affairs
 source $HOME/deploy/envs/veterans-affairs.env
-$HOME/bin/analytics --publish --frequency=realtime --slim --verbose --write-to-database
+$HOME/bin/analytics --publish --frequency=realtime --slim --verbose
 $HOME/bin/analytics --publish --only=all-pages-realtime --slim --verbose --csv
 
 # National Aeronautics and Space Administration
 source $HOME/deploy/envs/national-aeronautics-space-administration.env
-$HOME/bin/analytics --publish --frequency=realtime --slim --verbose --write-to-database
+$HOME/bin/analytics --publish --frequency=realtime --slim --verbose
 $HOME/bin/analytics --publish --only=all-pages-realtime --slim --verbose --csv
 
 # Department of Justice
 source $HOME/deploy/envs/justice.env
-$HOME/bin/analytics --publish --frequency=realtime --slim --verbose --write-to-database
+$HOME/bin/analytics --publish --frequency=realtime --slim --verbose
 $HOME/bin/analytics --publish --only=all-pages-realtime --slim --verbose --csv
 
 # Department of Commerce
 source $HOME/deploy/envs/commerce.env
-$HOME/bin/analytics --publish --frequency=realtime --slim --verbose --write-to-database
+$HOME/bin/analytics --publish --frequency=realtime --slim --verbose
 $HOME/bin/analytics --publish --only=all-pages-realtime --slim --verbose --csv
 
 # Environmental Protection Agency
 source $HOME/deploy/envs/environmental-protection-agency.env
-$HOME/bin/analytics --publish --frequency=realtime --slim --verbose --write-to-database
+$HOME/bin/analytics --publish --frequency=realtime --slim --verbose
 $HOME/bin/analytics --publish --only=all-pages-realtime --slim --verbose --csv
 
 # Small Business Administration
 source $HOME/deploy/envs/small-business-administration.env
-$HOME/bin/analytics --publish --frequency=realtime --slim --verbose --write-to-database
+$HOME/bin/analytics --publish --frequency=realtime --slim --verbose
 $HOME/bin/analytics --publish --only=all-pages-realtime --slim --verbose --csv
 
 # Department of Energy
 source $HOME/deploy/envs/energy.env
-$HOME/bin/analytics --publish --frequency=realtime --slim --verbose --write-to-database
+$HOME/bin/analytics --publish --frequency=realtime --slim --verbose
 $HOME/bin/analytics --publish --only=all-pages-realtime --slim --verbose --csv
 
 # Department of the Interior
 source $HOME/deploy/envs/interior.env
-$HOME/bin/analytics --publish --frequency=realtime --slim --verbose --write-to-database
+$HOME/bin/analytics --publish --frequency=realtime --slim --verbose
 $HOME/bin/analytics --publish --only=all-pages-realtime --slim --verbose --csv
 
 # National Archives and Records Administration
 source $HOME/deploy/envs/national-archives-records-administration.env
-$HOME/bin/analytics --publish --frequency=realtime --slim --verbose --write-to-database
+$HOME/bin/analytics --publish --frequency=realtime --slim --verbose
 $HOME/bin/analytics --publish --only=all-pages-realtime --slim --verbose --csv
 
 # Department of Agriculture
 source $HOME/deploy/envs/agriculture.env
-$HOME/bin/analytics --publish --frequency=realtime --slim --verbose --write-to-database
+$HOME/bin/analytics --publish --frequency=realtime --slim --verbose
 $HOME/bin/analytics --publish --only=all-pages-realtime --slim --verbose --csv
 
 # Department of Defense
 source $HOME/deploy/envs/defense.env
-$HOME/bin/analytics --publish --frequency=realtime --slim --verbose --write-to-database
+$HOME/bin/analytics --publish --frequency=realtime --slim --verbose
 $HOME/bin/analytics --publish --only=all-pages-realtime --slim --verbose --csv
 
 # Department of Health and Human Services
 source $HOME/deploy/envs/health-human-services.env
-$HOME/bin/analytics --publish --frequency=realtime --slim --verbose --write-to-database
+$HOME/bin/analytics --publish --frequency=realtime --slim --verbose
 $HOME/bin/analytics --publish --only=all-pages-realtime --slim --verbose --csv
 
 # Department of Housing and Urban Development
 source $HOME/deploy/envs/housing-urban-development.env
-$HOME/bin/analytics --publish --frequency=realtime --slim --verbose --write-to-database
+$HOME/bin/analytics --publish --frequency=realtime --slim --verbose
 $HOME/bin/analytics --publish --only=all-pages-realtime --slim --verbose --csv
 
 # Department of Homeland Security
 source $HOME/deploy/envs/homeland-security.env
-$HOME/bin/analytics --publish --frequency=realtime --slim --verbose --write-to-database
+$HOME/bin/analytics --publish --frequency=realtime --slim --verbose
 $HOME/bin/analytics --publish --only=all-pages-realtime --slim --verbose --csv
 
 # Department of Labor
 source $HOME/deploy/envs/labor.env
-$HOME/bin/analytics --publish --frequency=realtime --slim --verbose --write-to-database
+$HOME/bin/analytics --publish --frequency=realtime --slim --verbose
 $HOME/bin/analytics --publish --only=all-pages-realtime --slim --verbose --csv
 
 # Department of State
 source $HOME/deploy/envs/state.env
-$HOME/bin/analytics --publish --frequency=realtime --slim --verbose --write-to-database
+$HOME/bin/analytics --publish --frequency=realtime --slim --verbose
 $HOME/bin/analytics --publish --only=all-pages-realtime --slim --verbose --csv
 
 # Department of Transportation
 source $HOME/deploy/envs/transportation.env
-$HOME/bin/analytics --publish --frequency=realtime --slim --verbose --write-to-database
+$HOME/bin/analytics --publish --frequency=realtime --slim --verbose
 $HOME/bin/analytics --publish --only=all-pages-realtime --slim --verbose --csv
 
 # Department of the Treasury
 source $HOME/deploy/envs/treasury.env
-$HOME/bin/analytics --publish --frequency=realtime --slim --verbose --write-to-database
+$HOME/bin/analytics --publish --frequency=realtime --slim --verbose
 $HOME/bin/analytics --publish --only=all-pages-realtime --slim --verbose --csv
 
 # Agency for International Development
 source $HOME/deploy/envs/agency-international-development.env
-$HOME/bin/analytics --publish --frequency=realtime --slim --verbose --write-to-database
+$HOME/bin/analytics --publish --frequency=realtime --slim --verbose
 $HOME/bin/analytics --publish --only=all-pages-realtime --slim --verbose --csv
 
 # General Services Administration
 source $HOME/deploy/envs/general-services-administration.env
-$HOME/bin/analytics --publish --frequency=realtime --slim --verbose --write-to-database
+$HOME/bin/analytics --publish --frequency=realtime --slim --verbose
 $HOME/bin/analytics --publish --only=all-pages-realtime --slim --verbose --csv
 
 # National Science Foundation
 source $HOME/deploy/envs/national-science-foundation.env
-$HOME/bin/analytics --publish --frequency=realtime --slim --verbose --write-to-database
+$HOME/bin/analytics --publish --frequency=realtime --slim --verbose
 $HOME/bin/analytics --publish --only=all-pages-realtime --slim --verbose --csv
 
 # Nuclear Regulatory Commission
 source $HOME/deploy/envs/nuclear-regulatory-commission.env
-$HOME/bin/analytics --publish --frequency=realtime --slim --verbose --write-to-database
+$HOME/bin/analytics --publish --frequency=realtime --slim --verbose
 $HOME/bin/analytics --publish --only=all-pages-realtime --slim --verbose --csv
 
 # Office of Personnel Management
 source $HOME/deploy/envs/office-personnel-management.env
-$HOME/bin/analytics --publish --frequency=realtime --slim --verbose --write-to-database
+$HOME/bin/analytics --publish --frequency=realtime --slim --verbose
 $HOME/bin/analytics --publish --only=all-pages-realtime --slim --verbose --csv
 
 # Social Security Administration
 source $HOME/deploy/envs/social-security-administration.env
-$HOME/bin/analytics --publish --frequency=realtime --slim --verbose --write-to-database
+$HOME/bin/analytics --publish --frequency=realtime --slim --verbose
 $HOME/bin/analytics --publish --only=all-pages-realtime --slim --verbose --csv
 
 # Postal Service
 source $HOME/deploy/envs/postal-service.env
-$HOME/bin/analytics --publish --frequency=realtime --slim --verbose --write-to-database
+$HOME/bin/analytics --publish --frequency=realtime --slim --verbose
 $HOME/bin/analytics --publish --only=all-pages-realtime --slim --verbose --csv
 
 # Executive Office of the President
 source $HOME/deploy/envs/executive-office-president.env
-$HOME/bin/analytics --publish --frequency=realtime --slim --verbose --write-to-database
+$HOME/bin/analytics --publish --frequency=realtime --slim --verbose
 $HOME/bin/analytics --publish --only=all-pages-realtime --slim --verbose --csv

--- a/reports/api.json
+++ b/reports/api.json
@@ -1,0 +1,299 @@
+{
+  "reports": [
+    {
+      "name": "device",
+      "frequency": "daily",
+      "query": {
+        "dimensions": ["ga:date" ,"ga:deviceCategory"],
+        "metrics": ["ga:sessions"],
+        "start-date": "3daysAgo",
+        "end-date": "yesterday",
+        "filters": ["ga:sessions>100"]
+      },
+      "meta": {
+        "name": "Devices",
+        "description": "Desktop/mobile/tablet visits"
+      }
+    },
+    {
+      "name": "screen-size",
+      "frequency": "daily",
+      "query": {
+        "dimensions": ["ga:date" ,"ga:screenResolution"],
+        "metrics": ["ga:sessions"],
+        "start-date": "3daysAgo",
+        "end-date": "yesterday",
+        "filters": ["ga:sessions>100"]
+      },
+      "meta": {
+        "name": "Screen Resolutions",
+        "description": "Screen Resolutions of visiting devices"
+      }
+    },
+
+    {
+      "name": "language",
+      "frequency": "daily",
+      "query": {
+        "dimensions": ["ga:date" ,"ga:language"],
+        "metrics": ["ga:sessions"],
+        "start-date": "3daysAgo",
+        "end-date": "yesterday",
+        "filters": ["ga:sessions>100"]
+      },
+      "meta": {
+        "name": "Browser Languages",
+        "description": "Browser languages of visiting browsers"
+      }
+    },
+
+
+    {
+      "name": "device-model",
+      "frequency": "daily",
+      "query": {
+        "dimensions": ["ga:date" ,"ga:mobileDeviceModel"],
+        "metrics": ["ga:sessions"],
+        "start-date": "3daysAgo",
+        "end-date": "yesterday",
+        "filters": ["ga:sessions>100"]
+      },
+      "meta": {
+        "name": "Device Models",
+        "description": "Device models of visiting devices"
+      }
+    },
+    {
+      "name": "os",
+      "frequency": "daily",
+      "query": {
+        "dimensions": ["ga:date" ,"ga:operatingSystem"],
+        "metrics": ["ga:sessions"],
+        "start-date": "3daysAgo",
+        "end-date": "yesterday",
+        "filters": ["ga:sessions>100"]
+      },
+      "meta": {
+        "name": "Operating Systems",
+        "description": "Operating systems of visiting devices"
+      }
+    },
+    {
+      "name": "windows",
+      "frequency": "daily",
+      "query": {
+        "dimensions": ["ga:date" ,"ga:operatingSystemVersion"],
+        "metrics": ["ga:sessions"],
+        "start-date": "3daysAgo",
+        "end-date": "yesterday",
+        "filters": [
+          "ga:operatingSystem==Windows",
+          "ga:sessions>100"
+        ]
+      },
+      "meta": {
+        "name": "Windows",
+        "description": "Operating system of visiting windows devices"
+      }
+    },
+    {
+      "name": "browser",
+      "frequency": "daily",
+      "query": {
+        "dimensions": ["ga:date" ,"ga:browser"],
+        "metrics": ["ga:sessions"],
+        "start-date": "3daysAgo",
+        "end-date": "yesterday",
+        "filters": ["ga:sessions>100"]
+      },
+      "meta": {
+        "name": "Browsers",
+        "description": "Browsers of visiting users"
+      }
+    },
+    {
+      "name": "ie",
+      "frequency": "daily",
+      "query": {
+        "dimensions": ["ga:date","ga:browserVersion"],
+        "metrics": ["ga:sessions"],
+        "start-date": "3daysAgo",
+        "end-date": "yesterday",
+        "filters": [
+          "ga:browser==Internet Explorer",
+          "ga:sessions>100"
+        ]
+      },
+      "meta": {
+        "name": "Internet Explorer",
+        "description": "Visits from Internet Explorer users broken down by version"
+      }
+    },
+    {
+      "name": "os-browser",
+      "frequency": "daily",
+      "query": {
+        "dimensions": ["ga:date" ,"ga:browser", "ga:operatingSystem"],
+        "metrics": ["ga:sessions"],
+        "start-date": "3daysAgo",
+        "end-date": "yesterday",
+        "filters": ["ga:sessions>100"]
+      },
+      "meta": {
+        "name": "OS-browser combinations",
+        "description": "Visits broken down by browser and OS for all sites"
+      }
+    },
+    {
+      "name": "windows-browser",
+      "frequency": "daily",
+      "query": {
+        "dimensions": ["ga:date" ,"ga:browser", "ga:operatingSystemVersion"],
+        "metrics": ["ga:sessions"],
+        "start-date": "3daysAgo",
+        "end-date": "yesterday",
+        "filters": [
+          "ga:sessions>100",
+          "ga:operatingSystem==Windows"
+        ]
+      },
+      "meta": {
+        "name": "Windows-browser combinations",
+        "description": "Visits broken down by Windows versions and browser for all sites"
+      }
+    },
+    {
+      "name": "windows-ie",
+      "frequency": "daily",
+      "query": {
+        "dimensions": ["ga:date","ga:browserVersion", "ga:operatingSystemVersion"],
+        "metrics": ["ga:sessions"],
+        "start-date": "3daysAgo",
+        "end-date": "yesterday",
+        "filters": [
+          "ga:sessions>100",
+          "ga:browser==Internet Explorer",
+          "ga:operatingSystem==Windows"
+        ]
+      },
+      "meta": {
+        "name": "IE on Windows",
+        "description": "Visits from IE on Windows broken down by IE and Windows versions"
+      }
+    },
+    {
+      "name": "domain",
+      "frequency": "daily",
+      "query": {
+        "dimensions": ["ga:date", "ga:hostname"],
+        "metrics": ["ga:sessions", "ga:pageviews", "ga:users", "ga:pageviewsPerSession", "ga:avgSessionDuration", "ga:exits"],
+        "start-date": "3daysAgo",
+        "end-date": "yesterday",
+        "filters": ["ga:sessions>100"]
+      },
+      "meta": {
+        "name": "Domains",
+        "description": "Number of visitors for a given domain"
+      }
+    },
+    {
+      "name": "landing-page",
+      "frequency": "daily",
+      "query": {
+        "dimensions": ["ga:date", "ga:landingPagePath"],
+        "metrics": ["ga:sessions", "ga:pageviews", "ga:users", "ga:pageviewsPerSession", "ga:avgSessionDuration", "ga:exits"],
+        "start-date": "3daysAgo",
+        "end-date": "yesterday",
+        "filters": ["ga:sessions>100"]
+      },
+      "meta": {
+        "name": "Landing Pages",
+        "description": "Number of visitors to a given landing page path"
+      }
+    },
+
+    {
+      "name": "traffic-source",
+      "frequency": "daily",
+      "query": {
+        "dimensions": ["ga:date", "ga:source", "ga:hasSocialSourceReferral"],
+        "metrics": ["ga:sessions", "ga:pageviews", "ga:users", "ga:pageviewsPerSession", "ga:avgSessionDuration", "ga:exits"],
+        "start-date": "3daysAgo",
+        "end-date": "yesterday",
+        "filters": ["ga:sessions>100"]
+      },
+      "meta": {
+        "name": "Top Traffic Sources",
+        "description": "Visitors for a given traffic source"
+      }
+    },
+
+    {
+      "name": "exit-page",
+      "frequency": "daily",
+      "query": {
+        "dimensions": ["ga:date", "ga:exitPagePath"],
+        "metrics": ["ga:sessions", "ga:pageviews", "ga:users", "ga:pageviewsPerSession", "ga:avgSessionDuration", "ga:exits"],
+        "start-date": "3daysAgo",
+        "end-date": "yesterday",
+        "filters": ["ga:sessions>100"]
+      },
+      "meta": {
+        "name": "Exit Page",
+        "description": "Number of sessions for a given exit page"
+      }
+    },
+    {
+      "name": "second-level-domain",
+      "frequency": "daily",
+      "query": {
+        "dimensions": ["ga:date", "ga:hostname"],
+        "metrics": ["ga:sessions"],
+        "filters": [
+          "ga:sessions>100",
+          "ga:hostname=~^[^\\.]+\\.[^\\.]+$"
+        ],
+        "start-date": "3daysAgo",
+        "end-date": "yesterday"
+      },
+      "meta": {
+        "name": "Participating second-level domains.",
+        "description": "Visits to participating second-level domains"
+      }
+    },
+    {
+      "name": "site",
+      "frequency": "daily",
+      "query": {
+        "dimensions": ["ga:date", "ga:hostname"],
+        "metrics": ["ga:sessions"],
+        "filters": ["ga:sessions>100"],
+        "start-date": "3daysAgo",
+        "end-date": "yesterday"
+      },
+      "meta": {
+        "name": "Participating hostnames.",
+        "description": "Visits to participating hostnames"
+      }
+    },
+    {
+      "name": "download",
+      "frequency": "daily",
+      "query": {
+        "dimensions": ["ga:date", "ga:pageTitle", "ga:eventLabel", "ga:pagePath"],
+        "metrics": ["ga:totalEvents"],
+        "filters": [
+          "ga:eventCategory=~ownload",
+          "ga:pagePath!~(usps.com).*\/(?i)(zip|doc).*",
+          "ga:totalEvents>10"
+        ],
+        "start-date": "3daysAgo",
+        "end-date": "yesterday"
+      },
+      "meta": {
+        "name": "Downloads",
+        "description": "Number of download events"
+      }
+    }
+  ]
+}


### PR DESCRIPTION
This commit adds a new series of reports in a report file named `api.json`. These are reports that are meant to add data to the postgres database that backs the API. This commit configures the reporter so that only the results from reports in `api.json` are written to the database. Additionally, `api.json` contains only daily reports so it only needs to be run every 24 hours.

This advantage of this change is it allows us to manage the reports that feed analytics.usa.gov and the reports that feed to API separately so we can manage the data going into one without having to worry about side effects in the other. Additionally, it gives us finer grained control over data written to the API.

Additionally, this relieves the reporter from having to process a lot of the redundant data in the standard, more far-reaching reports (e.g. looking at data that is up to 90 days old and has already be inserted).

The thresholds on these reports can also be managed separately from the standard reports which allows for more aggressive downsampling.