### PR TITLE
Don't set timeout for daily reports to more than 24 hours

### DIFF
--- a/deploy/cron.js
+++ b/deploy/cron.js
@@ -70,6 +70,20 @@ var realtime_run = function(){
 	})
 }
 
+/**
+	Daily reports run every morning at 10 AM UTC.
+	This calculates the offset between now and then for the next scheduled run.
+*/
+var calculateNextDailyRunTimeOffset = function(){
+	const currentTime = new Date();
+	const nextRunTime = new Date(
+		currentTime.getFullYear(),
+		currentTime.getMonth(),
+		currentTime.getDate() + 1,
+		10 - currentTime.getTimezoneOffset() / 60
+	);
+	return (nextRunTime - currentTime) % (1000 * 60 * 60 * 24)
+}
 
 winston.info("starting cron.js!");
 api_run();
@@ -79,17 +93,11 @@ realtime_run();
 //api
 setInterval(api_run,1000 * 60 * 60 * 24)
 //daily
-const currentTime = new Date();
-const nextRunTime = new Date(
-	currentTime.getFullYear(),
-	currentTime.getMonth(),
-	currentTime.getDate() + 1,
-	10 - currentTime.getTimezoneOffset() / 60
-);
-setInterval(() => {
+setTimeout(() => {
+	// Run at 10 AM UTC, then every 24 hours afterwards
 	daily_run();
 	setInterval(daily_run, 1000 * 60 * 60 * 24);
-}, nextRunTime - currentTime);
+}, calculateNextDailyRunTimeOffset());
 //hourly
 setInterval(hourly_run,1000 * 60 * 60);
 //realtime


### PR DESCRIPTION
There was an issue with the daily reports. They are supposed to run every morning at 10 AM UTC which translates to 5 AM or 6 AM depending on DST.

To calculate when they run, we increment the day in the current date, set the time to 10 AM UTC, and find the interval between then an now. This create a problem when the reporter is started late at night. 2 AM UTC is 10 PM the previous day in ET. This means that if the reporter is run at 10 PM ET on 2017-01-01, the date in UTC is 2017-01-02, so when the day is incremented, it is set to 2017-01-03. This means that the reporter will not run the next morning (morning of 2017-01-02), waiting a full day before running again.

This commit fixes the problem, by finding the modulo of the interval and 24 hours. This will prevent the interval from ever going over 24 hours, while still using the offset between the current data and 10 AM ET on the next day.