### PR TITLE
[HOLD] Change date_time column to date

### DIFF
--- a/package.json
+++ b/package.json
@@ -62,7 +62,6 @@
     "googleapis": "^2.1.5",
     "lodash": "^3.10.1",
     "minimist": "*",
-    "moment-timezone": "^0.5.11",
     "node-schedule": "^0.1.13",
     "winston-color": "^1.0.0"
   },

--- a/src/config.js
+++ b/src/config.js
@@ -48,6 +48,4 @@ module.exports = {
   static: {
     path: '../analytics.usa.gov/',
   },
-
-  timezone: process.env.ANALYTICS_TIMEZONE || "US/Eastern",
 };

--- a/test/support/database.js
+++ b/test/support/database.js
@@ -15,7 +15,7 @@ const resetSchema = () => {
       table.increments("id")
       table.string("report_name")
       table.string("report_agency")
-      table.dateTime("date_time")
+      table.date("date")
       table.jsonb("data")
       table.timestamps(true, true)
     })


### PR DESCRIPTION
This commit makes the reporter aware that the schema in 18f/analytics-reporter-api has changed such that the `date_time` column has become a `date` column. Now that we are only tracking data on a daily basis, it does not make sense to have down to the millisecond data.

Ref #226
Ref 18f/analytics-reporter-api#3