### PR TITLE
Add agency name to log output

### DIFF
--- a/index.js
+++ b/index.js
@@ -12,6 +12,7 @@ const S3Publisher = require("./src/publish/s3")
 
 winston.transports.console.level = "info"
 winston.transports.console.prettyPrint = true
+winston.transports.console.label = config.account.agency_name || "live"
 
 const run = function(options = {}) {
   if (options.debug || options.verbose) {


### PR DESCRIPTION
This commit adds a label to the winston console transport when the
reporter is started. This label has the name of the agency for which the
report is being executed. This should be helpful for debugging
situations where a particular report is not behaving appropriatly.