### PR TITLE
Fix issue where daily.sh was exiting early.

### DIFF
--- a/deploy/cron.js
+++ b/deploy/cron.js
@@ -7,18 +7,17 @@ if (process.env.NEW_RELIC_APP_NAME) {
 	winston.warn("Skipping New Relic Activation")
 }
 
-const spawn = require("child_process").exec;
-const execSync = require("child_process").execSync;
+const spawn = require("child_process").spawn;
 
 var api_run = function() {
 	winston.info("about to run api.sh");
 
 	var api = spawn("./deploy/api.sh")
 	api.stdout.on("data", (data) => {
-		winston.info("[api.sh]", data)
+		winston.info("[api.sh]", data.toString().trim())
 	})
 	api.stderr.on("data", (data) => {
-		winston.info("[api.sh]", data)
+		winston.info("[api.sh]", data.toString().trim())
 	})
 	api.on("exit", (code) => {
 		winston.info("api.sh exitted with code:", code)
@@ -30,10 +29,10 @@ var daily_run = function() {
 
 	var daily = spawn("./deploy/daily.sh")
 	daily.stdout.on("data", (data) => {
-		winston.info("[daily.sh]", data)
+		winston.info("[daily.sh]", data.toString().trim())
 	})
 	daily.stderr.on("data", (data) => {
-		winston.info("[daily.sh]", data)
+		winston.info("[daily.sh]", data.toString().trim())
 	})
 	daily.on("exit", (code) => {
 		winston.info("daily.sh exitted with code:", code)
@@ -45,10 +44,10 @@ var hourly_run = function(){
 
 	var hourly = spawn("./deploy/hourly.sh")
 	hourly.stdout.on("data", (data) => {
-		winston.info("[hourly.sh]", data)
+		winston.info("[hourly.sh]", data.toString().trim())
 	})
 	hourly.stderr.on("data", (data) => {
-		winston.info("[hourly.sh]", data)
+		winston.info("[hourly.sh]", data.toString().trim())
 	})
 	hourly.on("exit", (code) => {
 		winston.info("hourly.sh exitted with code:", code)
@@ -60,10 +59,10 @@ var realtime_run = function(){
 
 	var realtime = spawn("./deploy/realtime.sh")
 	realtime.stdout.on("data", (data) => {
-		winston.info("[realtime.sh]", data)
+		winston.info("[realtime.sh]", data.toString().trim())
 	})
 	realtime.stderr.on("data", (data) => {
-		winston.info("[realtime.sh]", data)
+		winston.info("[realtime.sh]", data.toString().trim())
 	})
 	realtime.on("exit", (code) => {
 		winston.info("realtime.sh exitted with code:", code)


### PR DESCRIPTION
The `daily.sh` script was misbehaving. It exits right around the time it started processing HUD data. After a little investigation, I realized this was because it was receiving a SIGTERM. This was because we were still using `child_process.exec` instead of `child_process.spawn`, which implement a similar API, but behave slightly differently.

`child_process.exec` has a max buffer size, meaning that whenever the the output exceeds a certain length, it exits and returns a string that says `Max buffer size exceeded`. But, since we were looking at the `stdout`, `stdin`, and `exit` events instead of the callback, we never saw this. As a result, the buffer size was being exceeded and the process was exitting without us being aware of why.

This commit changes require so we are using the intended function, and also makes some other slight changes to use the `child_process.spawn` API.

closes #18f/analytics.usa.gov#451