### PR TITLE
Don't initialize database connection when reports won't be written

### DIFF
--- a/src/publish/postgres.js
+++ b/src/publish/postgres.js
@@ -5,9 +5,8 @@ const Promise = require("bluebird")
 const config = require("../config")
 
 const publish = (results) => {
-  const db = knex({ client: "pg", connection: config.postgres })
-
   if (results.query.dimensions.match(/ga:date/)) {
+    const db = knex({ client: "pg", connection: config.postgres })
     return _writeRegularResults({ db, results }).then(() => db.destroy())
   } else {
     return Promise.resolve()


### PR DESCRIPTION
This commit changes the postgres connection so it never initializes a new database object if report is not elligible to be written to the database.