### PR TITLE
Switch to built in cloud.gov buildpack

### DIFF
--- a/manifest.yml
+++ b/manifest.yml
@@ -5,7 +5,7 @@ applications:
   disk_quota: 1024M
   no-route: true
   health-check-type: process
-  buildpack: https://github.com/cloudfoundry/nodejs-buildpack
+  buildpack: nodejs_buildpack
   command: node deploy/cron.js
   # These are examples. These variables are set via `cg-toolkit/generate-env.sh`
   # using the `.env` file referenced in README.md.


### PR DESCRIPTION
This commit changes the buildpack from the Cloud Foundry node.js
buildpack to the buildpack provided by cloud.gov.