### PR TITLE
Filter NCBI hostnames from the top 20 realtime pages

### DIFF
--- a/reports/usa.json
+++ b/reports/usa.json
@@ -238,7 +238,10 @@
         "dimensions": ["rt:pagePath", "rt:pageTitle"],
         "metrics": ["rt:activeUsers"],
         "sort": "-rt:activeUsers",
-        "max-results": "20"
+        "max-results": "20",
+        "filters":[
+          "ga:hostname!=ncbi.nlm.nih.gov"
+        ]
       },
       "meta": {
         "name": "Top Pages (Live)",


### PR DESCRIPTION
The NCBI DAP implementation aggregates their pages. This means that requests for a bunch of pages are rolled into one, and that one page shoots to the top of the list. This commit filters NCBI so those pages don't pollute the top 20 since they aren't actually requests for a single page.