### PR TITLE
Hone filter

### DIFF
--- a/reports/usa.json
+++ b/reports/usa.json
@@ -240,7 +240,7 @@
         "sort": "-rt:activeUsers",
         "max-results": "20",
         "filters":[
-          "rt:pagePath!~^ncbi\\.nlm\\.nih\\.gov.*"
+          "rt:pagePath!~^ncbi\\.nlm\\.nih\\.gov/ncbi_.*"
         ]
       },
       "meta": {


### PR DESCRIPTION
After discussion with NCBI, we want to exclude pages that begin with `ncbi.nlm.nih.gov/ncbi_` since those are the aggregated collections. There will be a few actual individual page that do not match that string which will now appear on the "Now" chart.