### PR TITLE
Further honing filter

### DIFF
--- a/reports/usa.json
+++ b/reports/usa.json
@@ -240,7 +240,7 @@
         "sort": "-rt:activeUsers",
         "max-results": "20",
         "filters":[
-          "rt:pagePath!~^ncbi\\.nlm\\.nih\\.gov/ncbi_.*"
+          "rt:pagePath!~ncbi\\.nlm\\.nih\\.gov/ncbi_.*"
         ]
       },
       "meta": {


### PR DESCRIPTION
NCBI wishes to remove any further subdomains of ncbi.nlm.nih.gov/ncbi_* as well as the main ncbi.nlm.nih.gov/ncbi_*. I am removing the caret to make the string more greedy, and catch things like pubchem.ncbi.nlm..... and blast.ncbi.nlm.....