### PR TITLE
Upgrade to cflinuxfs3 stack

### DIFF
--- a/manifest.yml
+++ b/manifest.yml
@@ -26,6 +26,6 @@ applications:
   - analytics-s3
   - analytics-env
   - analytics-reporter-database
-  stack: cflinuxfs2
+  stack: cflinuxfs3
   timeout: 180
   path: .


### PR DESCRIPTION
We need to upgrade this because cloud.gov is going to stop supporting cflinuxfs2.