### PR TITLE
Restrict download event categories

### DIFF
--- a/reports/api.json
+++ b/reports/api.json
@@ -249,7 +249,7 @@
         "dimensions": ["ga:date", "ga:pageTitle", "ga:eventLabel", "ga:pagePath"],
         "metrics": ["ga:totalEvents"],
         "filters": [
-          "ga:eventCategory=~ownload",
+          "ga:eventCategory=~^(download|downloads|(outbound downloads))$",
           "ga:pagePath!~(usps.com).*\/(?i)(zip|doc).*",
           "ga:totalEvents>100"
         ],

--- a/reports/usa.json
+++ b/reports/usa.json
@@ -399,7 +399,7 @@
         "dimensions": ["ga:pageTitle", "ga:eventLabel", "ga:pagePath"],
         "metrics": ["ga:totalEvents"],
         "filters": [
-          "ga:eventCategory=~ownload",
+          "ga:eventCategory=~^(download|downloads|(outbound downloads))$",
           "ga:pagePath!~(usps.com).*\/(?i)(zip|doc).*"
         ],
         "start-date": "yesterday",
@@ -419,7 +419,7 @@
         "dimensions": ["ga:pageTitle", "ga:eventLabel", "ga:pagePath"],
         "metrics": ["ga:totalEvents"],
         "filters": [
-          "ga:eventCategory=~ownload",
+          "ga:eventCategory=~^(download|downloads|(outbound downloads))$",
           "ga:eventLabel!~swf$",
           "ga:pagePath!~(usps.com).*\/(?i)(zip|doc).*"
         ],


### PR DESCRIPTION
The existing reports for download events are permissive, selecting all events with a category containing "ownload". This has the side effect of including custom categories agencies create themselves, like "Direct Downloads", which is not desired. These custom events don't always represent a download from a page and will have unset page titles, etc.