### PR TITLE
Create new api endpoint for longer/seasonal session data

### DIFF
--- a/reports/usa.json
+++ b/reports/usa.json
@@ -13,6 +13,21 @@
       }
     },
     {
+      "name": "traffic-sources-30-days",
+      "frequency": "daily",
+      "query": {
+        "dimensions": ["ga:date"],
+        "metrics": ["ga:sessions"],
+        "start-date": "30daysAgo",
+        "end-date": "yesterday",
+        "sort": "-ga:date"
+      },
+      "meta": {
+        "name": "Traffic Sources (30 Days)",
+        "description": "Last 30 days' Traffic Sources, measured by sessions, for all sites."
+      }
+    },
+    {
       "name": "today",
       "frequency": "hourly",
       "query": {


### PR DESCRIPTION
This endpoint would be used for a new bar-chart on analytics.usa.gov:
https://github.com/18F/analytics.usa.gov

If we want to change the "Visits Today" bar-chart into something more seasonal, we may need to generate a new report like this, since there isn't an equivalent report in the list.

This query is modeled off USA.gov's Last 30 Days endpoint:
https://app-usa-modeast-prod-a01239f-ecas.s3.amazonaws.com/analytics/raw-data/traffic-sources-30-days.json

We can tweak the number of days to last 90, last 365, or whatever length of days we decide.