### PR TITLE
Increment to cflinuxfs4

### DIFF
--- a/manifest.yml
+++ b/manifest.yml
@@ -26,6 +26,6 @@ applications:
   - analytics-s3
   - analytics-env
   - analytics-reporter-database
-  stack: cflinuxfs3
+  stack: cflinuxfs4
   timeout: 180
   path: .


### PR DESCRIPTION
This PR tracks work on remediating the Clloud.gov Ubuntu stack dependency moving from cflinuxfs3 to 4. 
