### PR TITLE
comment out publish crons testing temp

### DIFF
--- a/deploy/cron.js
+++ b/deploy/cron.js
@@ -37,80 +37,80 @@ var api_run = function() {
 	})
 }
 
-var daily_run = function() {
-	logger.info("about to run daily.sh");
+// var daily_run = function() {
+// 	logger.info("about to run daily.sh");
 
-	var daily = spawn(`${scriptRootPath}/daily.sh`)
-	daily.stdout.on("data", (data) => {
-		logger.info("[daily.sh]", data.toString().trim())
-	})
-	daily.stderr.on("data", (data) => {
-		logger.info("[daily.sh]", data.toString().trim())
-	})
-	daily.on("exit", (code) => {
-		logger.info("daily.sh exitted with code:", code)
-	})
-}
+// 	var daily = spawn(`${scriptRootPath}/daily.sh`)
+// 	daily.stdout.on("data", (data) => {
+// 		logger.info("[daily.sh]", data.toString().trim())
+// 	})
+// 	daily.stderr.on("data", (data) => {
+// 		logger.info("[daily.sh]", data.toString().trim())
+// 	})
+// 	daily.on("exit", (code) => {
+// 		logger.info("daily.sh exitted with code:", code)
+// 	})
+// }
 
-var hourly_run = function(){
-	logger.info("about to run hourly.sh");
+// var hourly_run = function(){
+// 	logger.info("about to run hourly.sh");
 
-	var hourly = spawn(`${scriptRootPath}/hourly.sh`)
-	hourly.stdout.on("data", (data) => {
-		logger.info("[hourly.sh]", data.toString().trim())
-	})
-	hourly.stderr.on("data", (data) => {
-		logger.info("[hourly.sh]", data.toString().trim())
-	})
-	hourly.on("exit", (code) => {
-		logger.info("hourly.sh exitted with code:", code)
-	})
-}
+// 	var hourly = spawn(`${scriptRootPath}/hourly.sh`)
+// 	hourly.stdout.on("data", (data) => {
+// 		logger.info("[hourly.sh]", data.toString().trim())
+// 	})
+// 	hourly.stderr.on("data", (data) => {
+// 		logger.info("[hourly.sh]", data.toString().trim())
+// 	})
+// 	hourly.on("exit", (code) => {
+// 		logger.info("hourly.sh exitted with code:", code)
+// 	})
+// }
 
-var realtime_run = function(){
-	logger.info("about to run realtime.sh");
+// var realtime_run = function(){
+// 	logger.info("about to run realtime.sh");
 
-	var realtime = spawn(`${scriptRootPath}/realtime.sh`)
-	realtime.stdout.on("data", (data) => {
-		logger.info("[realtime.sh]", data.toString().trim())
-	})
-	realtime.stderr.on("data", (data) => {
-		logger.info("[realtime.sh]", data.toString().trim())
-	})
-	realtime.on("exit", (code) => {
-		logger.info("realtime.sh exitted with code:", code)
-	})
-}
+// 	var realtime = spawn(`${scriptRootPath}/realtime.sh`)
+// 	realtime.stdout.on("data", (data) => {
+// 		logger.info("[realtime.sh]", data.toString().trim())
+// 	})
+// 	realtime.stderr.on("data", (data) => {
+// 		logger.info("[realtime.sh]", data.toString().trim())
+// 	})
+// 	realtime.on("exit", (code) => {
+// 		logger.info("realtime.sh exitted with code:", code)
+// 	})
+// }
 
-/**
-	Daily reports run every morning at 10 AM UTC.
-	This calculates the offset between now and then for the next scheduled run.
-*/
-var calculateNextDailyRunTimeOffset = function(){
-	const currentTime = new Date();
-	const nextRunTime = new Date(
-		currentTime.getFullYear(),
-		currentTime.getMonth(),
-		currentTime.getDate() + 1,
-		10 - currentTime.getTimezoneOffset() / 60
-	);
-	return (nextRunTime - currentTime) % (1000 * 60 * 60 * 24)
-}
+// /**
+// 	Daily reports run every morning at 10 AM UTC.
+// 	This calculates the offset between now and then for the next scheduled run.
+// */
+// var calculateNextDailyRunTimeOffset = function(){
+// 	const currentTime = new Date();
+// 	const nextRunTime = new Date(
+// 		currentTime.getFullYear(),
+// 		currentTime.getMonth(),
+// 		currentTime.getDate() + 1,
+// 		10 - currentTime.getTimezoneOffset() / 60
+// 	);
+// 	return (nextRunTime - currentTime) % (1000 * 60 * 60 * 24)
+// }
 
 logger.info("starting cron.js!");
 api_run();
-daily_run();
-hourly_run();
-realtime_run();
+// daily_run();
+// hourly_run();
+// realtime_run();
 //api
 setInterval(api_run,1000 * 60 * 60 * 24)
-//daily
-setTimeout(() => {
-	// Run at 10 AM UTC, then every 24 hours afterwards
-	daily_run();
-	setInterval(daily_run, 1000 * 60 * 60 * 24);
-}, calculateNextDailyRunTimeOffset());
-//hourly
-setInterval(hourly_run,1000 * 60 * 60);
-//realtime
-setInterval(realtime_run,1000 * 60 * 5);
+// //daily
+// setTimeout(() => {
+// 	// Run at 10 AM UTC, then every 24 hours afterwards
+// 	daily_run();
+// 	setInterval(daily_run, 1000 * 60 * 60 * 24);
+// }, calculateNextDailyRunTimeOffset());
+// //hourly
+// setInterval(hourly_run,1000 * 60 * 60);
+// //realtime
+// setInterval(realtime_run,1000 * 60 * 5);


### PR DESCRIPTION
This temporarily comments out cron tasks that publish to s3 from `analytics-reporter-develop` application.  We are currently running a second application in `analytics-reporter-develop-ga4` that contains GA4 data.  We are testing to simulate the following write process scenario

`analytics-reporter-develop` only writes to db at `<path>/1.1/<endpoint>`
`analytics-reporter-develop-ga4` writes to db at `<path>/1.2/<endpoint>` and s3 reports