### PR TITLE
Update deploy health check

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -57,7 +57,7 @@ jobs:
               # Log into cloud.gov
               cf api api.fr.cloud.gov
               cf login -u $CF_USERNAME_DEV -p $CF_PASSWORD_DEV -o gsa-opp-analytics -s analytics-dev
-              cf push analytics-reporter-develop --health-check-type process --strategy rolling
+              cf push analytics-reporter-develop --strategy rolling
               cf logout
 
   staging_deploy:

--- a/deploy/cron.js
+++ b/deploy/cron.js
@@ -102,14 +102,17 @@ api_run();
 // daily_run();
 // hourly_run();
 // realtime_run();
-//api
-setInterval(api_run,1000 * 60 * 60 * 24)
+// //api
+// setInterval(api_run,1000 * 60 * 60 * 24)
 // //daily
-// setTimeout(() => {
-// 	// Run at 10 AM UTC, then every 24 hours afterwards
-// 	daily_run();
-// 	setInterval(daily_run, 1000 * 60 * 60 * 24);
-// }, calculateNextDailyRunTimeOffset());
+setTimeout(() => {
+	// Run at 10 AM UTC, then every 24 hours afterwards
+	// daily_run();
+	// setInterval(daily_run, 1000 * 60 * 60 * 24);
+	//api
+	api_run();
+	setInterval(api_run,1000 * 60 * 60 * 24)
+}, calculateNextDailyRunTimeOffset());
 // //hourly
 // setInterval(hourly_run,1000 * 60 * 60);
 // //realtime


### PR DESCRIPTION
- reverts healthcheck
- moves api_run into the `calculateNextDailyRunTimeOffset()` timer to ensure new run within 24hrs