### PR TITLE
Update npm packages picked

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,6 +1,6 @@
- x[![Code Climate](https://codeclimate.com/github/18F/analytics-reporter/badges/gpa.svg)](https://codeclimate.com/github/18F/analytics-reporter)
- [![CircleCI](https://circleci.com/gh/18F/analytics.usa.gov.svg?style=shield)](https://circleci.com/gh/18F/analytics.usa.gov)
- [![Dependency Status](https://gemnasium.com/badges/github.com/18F/analytics-reporter.svg)](https://gemnasium.com/github.com/18F/analytics-reporter)
+[![CircleCI](https://circleci.com/gh/18F/analytics.usa.gov.svg?style=shield)](https://circleci.com/gh/18F/analytics.usa.gov)
+[![Snyk](https://snyk.io/test/github/18F/analytics-reporter/badge.svg)](https://snyk.io/test/github/18F/analytics-reporter)
+[![Code Climate](https://codeclimate.com/github/18F/analytics-reporter/badges/gpa.svg)](https://codeclimate.com/github/18F/analytics-reporter)
 
 ## Analytics Reporter
 
@@ -11,7 +11,6 @@ and the [Google Analytics Real Time API v3](https://developers.google.com/analyt
 This is used in combination with [analytics-reporter](https://github.com/18F/analytics-reporter-api) and [analytics.usa.gov](https://github.com/18F/analytics.usa.gov) to power the government analytics website, [analytics.usa.gov](https://analytics.usa.gov).
 
 Available reports are named and described in [`reports.json`](reports/reports.json). For now, they're hardcoded into the repository.
-
 
 ### Installation
 

--- a/package.json
+++ b/package.json
@@ -60,8 +60,8 @@
     "url": "https://github.com/18F/analytics-reporter/issues"
   },
   "dependencies": {
-    "@snyk/protect": "^1.1267.0",
-    "aws-sdk": "^2.1531.0",
+    "@snyk/protect": "^1.1269.0",
+    "aws-sdk": "^2.1533.0",
     "dotenv": "^16.3.1",
     "fast-csv": "^4.3.6",
     "googleapis": "^19.0.0",
@@ -69,13 +69,13 @@
     "winston": "^3.11.0"
   },
   "devDependencies": {
-    "chai": "^4.3.10",
+    "chai": "^4.4.0",
     "mocha": "^10.2.0",
     "proxyquire": "^2.1.3"
   },
   "optionalDependencies": {
     "knex": "^3.1.0",
-    "newrelic": "^11.8.0",
+    "newrelic": "^11.9.0",
     "pg": "^8.11.3"
   },
   "snyk": true


### PR DESCRIPTION
This work cherry-picks node update commits from develop  and brings them into stage so we can go upstream without ongoing work from develop that is not required for this dependencies update.