### PR TITLE
Fix ua client

### DIFF
--- a/ua/src/google-analytics/client.js
+++ b/ua/src/google-analytics/client.js
@@ -1,13 +1,13 @@
-const googleapis = require("googleapis")
-const GoogleAnalyticsQueryAuthorizer = require("./query-authorizer")
-const GoogleAnalyticsQueryBuilder = require("./query-builder")
+const { google } = require("googleapis");
+const GoogleAnalyticsQueryAuthorizer = require("./query-authorizer");
+const GoogleAnalyticsQueryBuilder = require("./query-builder");
 
 const fetchData = (report) => {
-  const query = GoogleAnalyticsQueryBuilder.buildQuery(report)
-  return GoogleAnalyticsQueryAuthorizer.authorizeQuery(query).then(query => {
-    return _executeFetchDataRequest(query)
-  })
-}
+  const query = GoogleAnalyticsQueryBuilder.buildQuery(report);
+  return GoogleAnalyticsQueryAuthorizer.authorizeQuery(query).then((query) => {
+    return _executeFetchDataRequest(query);
+  });
+};
 
 const _executeFetchDataRequest = (query) => {
   return new Promise(async (resolve, reject) => {
@@ -18,12 +18,11 @@ const _executeFetchDataRequest = (query) => {
       reject(err);
     }
   });
-}
+};
 
 const _get = (query) => {
-  const analytics = googleapis.analytics({ version: 'v3' })
-  return analytics.data.ga.get(query)
-}
+  const analytics = google.analytics({ version: "v3" });
+  return analytics.data.ga.get(query);
+};
 
-module.exports = { fetchData }
-
+module.exports = { fetchData };

--- a/ua/test/google-analytics/client.test.js
+++ b/ua/test/google-analytics/client.test.js
@@ -1,83 +1,92 @@
-const expect = require("chai").expect
-const proxyquire = require("proxyquire")
-const googleAPIsMock = require("../support/mocks/googleapis-analytics")
+const expect = require("chai").expect;
+const proxyquire = require("proxyquire");
+const googleAPIsMock = require("../support/mocks/googleapis-analytics");
 
-proxyquire.noCallThru()
+proxyquire.noCallThru();
 
-let googleapis
-let GoogleAnalyticsQueryAuthorizer
-let GoogleAnalyticsQueryBuilder
-let report
+let googleapis;
+let GoogleAnalyticsQueryAuthorizer;
+let GoogleAnalyticsQueryBuilder;
+let report;
 
-let GoogleAnalyticsClient
+let GoogleAnalyticsClient;
 
 describe("GoogleAnalyticsClient", () => {
   describe(".fetchData(query, options)", () => {
     beforeEach(() => {
-      googleapis = googleAPIsMock()
-      GoogleAnalyticsQueryAuthorizer = { authorizeQuery: (query) => Promise.resolve(query) }
-      GoogleAnalyticsQueryBuilder = { buildQuery: () => ({}) }
+      googleapis = googleAPIsMock();
+      const { analytics } = googleapis;
+      GoogleAnalyticsQueryAuthorizer = {
+        authorizeQuery: (query) => Promise.resolve(query),
+      };
+      GoogleAnalyticsQueryBuilder = { buildQuery: () => ({}) };
 
       GoogleAnalyticsClient = proxyquire("../../src/google-analytics/client", {
-        googleapis,
+        googleapis: { google: { analytics } },
         "./query-authorizer": GoogleAnalyticsQueryAuthorizer,
         "./query-builder": GoogleAnalyticsQueryBuilder,
-      })
-    })
+      });
+    });
 
-    it("should build and authorize a query and use that to call the google api", done => {
-      const report = { name: "realtime" }
+    it("should build and authorize a query and use that to call the google api", (done) => {
+      const report = { name: "realtime" };
 
-      let queryBuilderCalled = false
+      let queryBuilderCalled = false;
       GoogleAnalyticsQueryBuilder.buildQuery = (report) => {
-        expect(report).to.deep.equal({ name: "realtime" })
-        queryBuilderCalled = true
-        return { query: true }
-      }
+        expect(report).to.deep.equal({ name: "realtime" });
+        queryBuilderCalled = true;
+        return { query: true };
+      };
 
-      let queryAuthorizerCalled = false
+      let queryAuthorizerCalled = false;
       GoogleAnalyticsQueryAuthorizer.authorizeQuery = (query) => {
-        queryAuthorizerCalled = true
-        expect(query).to.deep.equal({ query: true })
-        query.authorized = true
-        return Promise.resolve(query)
-      }
+        queryAuthorizerCalled = true;
+        expect(query).to.deep.equal({ query: true });
+        query.authorized = true;
+        return Promise.resolve(query);
+      };
 
-      let googleAPICalled = false
+      let googleAPICalled = false;
       googleapis.ga.get = (params) => {
-        googleAPICalled = true
-        expect(params).to.deep.equal({ query: true, authorized: true })
-      }
+        googleAPICalled = true;
+        expect(params).to.deep.equal({ query: true, authorized: true });
+      };
 
-      GoogleAnalyticsClient.fetchData(report).then(() => {
-        expect(queryBuilderCalled).to.be.true
-        expect(queryAuthorizerCalled).to.be.true
-        expect(googleAPICalled).to.be.true
-        done()
-      }).catch(done)
-    })
+      GoogleAnalyticsClient.fetchData(report)
+        .then(() => {
+          expect(queryBuilderCalled).to.be.true;
+          expect(queryAuthorizerCalled).to.be.true;
+          expect(googleAPICalled).to.be.true;
+          done();
+        })
+        .catch(done);
+    });
 
-    it("should return a promise for Google Analytics data", done => {
+    it("should return a promise for Google Analytics data", (done) => {
       googleapis.ga.get = (params, cb) => {
-        return { data: "that's me" }
-      }
+        return { data: "that's me" };
+      };
 
-      GoogleAnalyticsClient.fetchData({}).then(result => {
-        expect(result).to.deep.equal({ data: "that's me" })
-        done()
-      }).catch(done)
-    })
+      GoogleAnalyticsClient.fetchData({})
+        .then((result) => {
+          expect(result).to.deep.equal({ data: "that's me" });
+          done();
+        })
+        .catch(done);
+    });
 
-    it("should reject if there is a problem fetching data", done => {
+    it("should reject if there is a problem fetching data", (done) => {
       googleapis.ga.get = (params) => {
-        const error = new Error("i'm an error")
+        const error = new Error("i'm an error");
         throw error;
-      }
+      };
 
-      GoogleAnalyticsClient.fetchData({}).catch(error => {
-        expect(error.message).to.equal("i'm an error")
-        done()
-      }).catch(done)
-    })
-  })
-})
+      GoogleAnalyticsClient.fetchData({})
+        .catch((error) => {
+          expect(error.message).to.equal("i'm an error");
+          done();
+        })
+        .catch(done);
+    });
+  });
+});


### PR DESCRIPTION
latest version of module `googleapis` requires us to destructure goole on import. This changes how we need to handle the mock request in our test as well.