### PR TITLE
Add reports for traffic sources with totals for charts on the site

### DIFF
--- a/reports/usa.json
+++ b/reports/usa.json
@@ -57,6 +57,9 @@
       "name": "screen-size",
       "frequency": "daily",
       "slim": true,
+      "sumVisitsByColumns": [
+        "screen_resolution"
+      ],
       "query": {
         "dimensions": [
           {
@@ -106,6 +109,10 @@
       "name": "language",
       "frequency": "daily",
       "slim": true,
+      "sumVisitsByColumns": [
+        "language",
+        "language_code"
+      ],
       "query": {
         "dimensions": [
           {
@@ -155,6 +162,9 @@
       "name": "devices",
       "frequency": "daily",
       "slim": true,
+      "sumVisitsByColumns": [
+        "device"
+      ],
       "query": {
         "dimensions": [
           {
@@ -193,6 +203,9 @@
       "name": "devices-90-days",
       "frequency": "daily",
       "slim": true,
+      "sumVisitsByColumns": [
+        "device"
+      ],
       "query": {
         "dimensions": [
           {
@@ -231,6 +244,9 @@
       "name": "device-model",
       "frequency": "daily",
       "slim": true,
+      "sumVisitsByColumns": [
+        "mobile_device"
+      ],
       "query": {
         "dimensions": [
           {
@@ -280,6 +296,9 @@
       "name": "os",
       "frequency": "daily",
       "slim": true,
+      "sumVisitsByColumns": [
+        "os"
+      ],
       "query": {
         "dimensions": [
           {
@@ -329,6 +348,9 @@
       "name": "os-90-days",
       "frequency": "daily",
       "slim": true,
+      "sumVisitsByColumns": [
+        "os"
+      ],
       "query": {
         "dimensions": [
           {
@@ -378,6 +400,9 @@
       "name": "windows",
       "frequency": "daily",
       "slim": true,
+      "sumVisitsByColumns": [
+        "os_version"
+      ],
       "query": {
         "dimensions": [
           {
@@ -435,6 +460,9 @@
       "name": "windows-90-days",
       "frequency": "daily",
       "slim": true,
+      "sumVisitsByColumns": [
+        "os_version"
+      ],
       "query": {
         "dimensions": [
           {
@@ -492,6 +520,9 @@
       "name": "browsers",
       "frequency": "daily",
       "slim": true,
+      "sumVisitsByColumns": [
+        "browser"
+      ],
       "query": {
         "dimensions": [
           {
@@ -547,6 +578,9 @@
       "name": "browsers-90-days",
       "frequency": "daily",
       "slim": true,
+      "sumVisitsByColumns": [
+        "browser"
+      ],
       "query": {
         "dimensions": [
           {
@@ -807,11 +841,11 @@
             }
           }
         },
-        "limit": "20"
+        "limit": "30"
       },
       "meta": {
         "name": "Top Pages (Live)",
-        "description": "The top 20 pages, measured by active onsite users, for all sites. (>10 active users)"
+        "description": "The top 30 pages, measured by active onsite users, for all sites. (>10 active users)"
       }
     },
     {
@@ -881,11 +915,11 @@
             ]
           }
         },
-        "limit": "20"
+        "limit": "30"
       },
       "meta": {
         "name": "Top Domains (7 Days)",
-        "description": "Last week's top 20 domains, measured by visits, for all sites."
+        "description": "Last week's top 30 domains, measured by visits, for all sites."
       }
     },
     {
@@ -955,11 +989,11 @@
             ]
           }
         },
-        "limit": "20"
+        "limit": "30"
       },
       "meta": {
         "name": "Top Domains (30 Days)",
-        "description": "Last 30 days' top 20 domains, measured by visits, for all sites."
+        "description": "Last 30 days' top 30 domains, measured by visits, for all sites."
       }
     },
     {
@@ -1021,36 +1055,21 @@
       "query": {
         "dimensions": [
           {
-            "name": "sessionSource"
+            "name": "sessionDefaultChannelGroup"
           },
           {
-            "name": "sessionDefaultChannelGroup"
+            "name": "sessionSourceMedium"
           }
         ],
         "metrics": [
           {
             "name": "sessions"
-          },
-          {
-            "name": "screenPageViews"
-          },
-          {
-            "name": "totalUsers"
-          },
-          {
-            "name": "screenPageViewsPerSession"
-          },
-          {
-            "name": "averageSessionDuration"
-          },
-          {
-            "name": "bounceRate"
           }
         ],
         "orderBys": [
           {
             "metric": {
-              "metricName": "screenPageViews"
+              "metricName": "sessions"
             },
             "desc": true
           }
@@ -1066,6 +1085,184 @@
       "meta": {
         "name": "Top Traffic Sources (30 Days)",
         "description": "Top 20 traffic sources for the last 30 days, measured by visits, for all sites."
+      }
+    },
+    {
+      "name": "top-session-channel-group-30-days",
+      "frequency": "daily",
+      "slim": true,
+      "sumVisitsByColumns": [
+        "session_default_channel_group"
+      ],
+      "query": {
+        "dimensions": [
+          {
+            "name": "sessionDefaultChannelGroup"
+          }
+        ],
+        "metrics": [
+          {
+            "name": "sessions"
+          }
+        ],
+        "orderBys": [
+          {
+            "metric": {
+              "metricName": "sessions"
+            },
+            "desc": true
+          }
+        ],
+        "dateRanges": [
+          {
+            "startDate": "30daysAgo",
+            "endDate": "yesterday"
+          }
+        ],
+        "dimensionFilter": {
+          "andGroup": {
+            "expressions": [
+              {
+                "notExpression": {
+                  "filter": {
+                    "fieldName": "sessionDefaultChannelGroup",
+                    "stringFilter": {
+                      "value": "unassigned",
+                      "caseSensitive": false
+                    }
+                  }
+                }
+              },
+              {
+                "notExpression": {
+                  "filter": {
+                    "fieldName": "sessionDefaultChannelGroup",
+                    "stringFilter": {
+                      "value": "paid other",
+                      "caseSensitive": false
+                    }
+                  }
+                }
+              },
+              {
+                "notExpression": {
+                  "filter": {
+                    "fieldName": "sessionDefaultChannelGroup",
+                    "stringFilter": {
+                      "value": "(other)",
+                      "caseSensitive": false
+                    }
+                  }
+                }
+              }
+            ]
+          }
+        },
+        "limit": "20"
+      },
+      "meta": {
+        "name": "Top Session Default Channel Groups (30 Days)",
+        "description": "Top 20 channel groups that initiated a session for the last 30 days, measured by visits, for all sites."
+      }
+    },
+    {
+      "name": "top-session-source-medium-30-days",
+      "frequency": "daily",
+      "slim": true,
+      "sumVisitsByColumns": [
+        "session_source_medium"
+      ],
+      "query": {
+        "dimensions": [
+          {
+            "name": "sessionSourceMedium"
+          }
+        ],
+        "metrics": [
+          {
+            "name": "sessions"
+          }
+        ],
+        "orderBys": [
+          {
+            "metric": {
+              "metricName": "sessions"
+            },
+            "desc": true
+          }
+        ],
+        "dateRanges": [
+          {
+            "startDate": "30daysAgo",
+            "endDate": "yesterday"
+          }
+        ],
+        "dimensionFilter": {
+          "andGroup": {
+            "expressions": [
+              {
+                "notExpression": {
+                  "filter": {
+                    "fieldName": "sessionSourceMedium",
+                    "stringFilter": {
+                      "value": "(not set)",
+                      "caseSensitive": false
+                    }
+                  }
+                }
+              },
+              {
+                "notExpression": {
+                  "filter": {
+                    "fieldName": "sessionSourceMedium",
+                    "stringFilter": {
+                      "value": "other / email",
+                      "caseSensitive": false
+                    }
+                  }
+                }
+              },
+              {
+                "notExpression": {
+                  "filter": {
+                    "fieldName": "sessionSourceMedium",
+                    "stringFilter": {
+                      "value": "expected / email",
+                      "caseSensitive": false
+                    }
+                  }
+                }
+              },
+              {
+                "notExpression": {
+                  "filter": {
+                    "fieldName": "sessionSourceMedium",
+                    "stringFilter": {
+                      "value": "outfordelivery / email",
+                      "caseSensitive": false
+                    }
+                  }
+                }
+              },
+              {
+                "notExpression": {
+                  "filter": {
+                    "fieldName": "sessionSourceMedium",
+                    "stringFilter": {
+                      "value": "(other)",
+                      "caseSensitive": false
+                    }
+                  }
+                }
+              }
+            ]
+          }
+        },
+        "limit": "20"
+      },
+      "meta": {
+        "name": "Top Session Sources (30 Days)",
+        "description": "Top 20 sources that initiated a session for the last 30 days, measured by visits, for all sites."
       }
     },
     {
@@ -1256,7 +1453,7 @@
               {
                 "notExpression": {
                   "filter": {
-                    "fieldName": "hostname",
+                    "fieldName": "hostName",
                     "stringFilter": {
                       "value": "(other)",
                       "caseSensitive": false
@@ -1267,7 +1464,7 @@
               {
                 "notExpression": {
                   "filter": {
-                    "fieldName": "hostname",
+                    "fieldName": "hostName",
                     "stringFilter": {
                       "value": "null",
                       "caseSensitive": false
@@ -1278,7 +1475,7 @@
               {
                 "notExpression": {
                   "filter": {
-                    "fieldName": "hostname",
+                    "fieldName": "hostName",
                     "stringFilter": {
                       "value": "",
                       "caseSensitive": false
@@ -1289,11 +1486,11 @@
             ]
           }
         },
-        "limit": "20"
+        "limit": "30"
       },
       "meta": {
         "name": "Top Pages (30 Days)",
-        "description": "Top 20 pages for the last 30 days, measured by page views, for all sites."
+        "description": "Top 30 pages for the last 30 days, measured by page views, for all sites."
       }
     },
     {
@@ -1369,11 +1566,11 @@
             ]
           }
         },
-        "limit": "20"
+        "limit": "30"
       },
       "meta": {
         "name": "Top Pages (7 Days)",
-        "description": "Top 20 pages for the last week, measured by page views, for all sites."
+        "description": "Top 30 pages for the last week, measured by page views, for all sites."
       }
     },
     {
@@ -1802,22 +1999,11 @@
             ]
           }
         },
-        "metricFilter": {
-          "filter": {
-            "fieldName": "activeUsers",
-            "numericFilter": {
-              "operation": "GREATER_THAN",
-              "value": {
-                "int64Value": "10"
-              }
-            }
-          }
-        },
         "limit": "10000"
       },
       "meta": {
         "name": "Top 10000 Domains (30 Days)",
-        "description": "Last 30 days' domains, measured by page views, for the top 10000 sites. (>10 active users)"
+        "description": "Last 30 days' domains, measured by page views, for the top 10000 sites."
       }
     },
     {

--- a/src/config.js
+++ b/src/config.js
@@ -49,6 +49,10 @@ class Config {
     return !!this.#options["write-to-database"];
   }
 
+  /**
+   * @returns {Boolean} true if report configs with slim:true should have their
+   * data removed from report results and only include totals.
+   */
   get slim() {
     return !!this.#options.slim;
   }

--- a/src/process-results/analytics-data-processor.js
+++ b/src/process-results/analytics-data-processor.js
@@ -15,6 +15,7 @@ class AnalyticsDataProcessor {
     hostName: "domain",
     languageCode: "language_code",
     sessionSource: "source",
+    sessionSourceMedium: "session_source_medium",
     eventName: "event_label",
     eventCount: "total_events",
     landingPagePlusQueryString: "landing_page",
@@ -68,7 +69,9 @@ class AnalyticsDataProcessor {
       return this.#processRow({ row, report, data });
     });
 
-    result.totals = ResultTotalsCalculator.calculateTotals(result);
+    result.totals = ResultTotalsCalculator.calculateTotals(result, {
+      sumVisitsByColumns: report.sumVisitsByColumns,
+    });
 
     return result;
   }

--- a/src/process-results/result-totals-calculator.js
+++ b/src/process-results/result-totals-calculator.js
@@ -1,4 +1,12 @@
-const calculateTotals = (result) => {
+/**
+ * @param {Object} result the result of the analytics report API call after
+ * processing by the AnalyticsDataProcessor.
+ * @param {Object} options options for the ResultTotalsCalculator.
+ * @param {String[]} options.sumVisitsByColumns an array of columns to be
+ * totalled by the number of visits for each unique key in the column.
+ * @returns {Object} totals for the results.
+ */
+const calculateTotals = (result, options = {}) => {
   if (result.data.length === 0) {
     return {};
   }
@@ -13,52 +21,10 @@ const calculateTotals = (result) => {
     totals.visits = _sumColumn({ column: "visits", result });
   }
 
-  // Sum up categories
-  if (result.name.match(/^device_model/)) {
-    totals.device_models = _sumVisitsByColumn({
-      column: "mobile_device",
-      result,
-    });
-  }
-  if (result.name.match(/^language/)) {
-    totals.languages = _sumVisitsByColumn({
-      column: "language",
-      result,
-    });
-    totals.language_codes = _sumVisitsByColumn({
-      column: "language_code",
-      result,
-    });
-  }
-  if (result.name.match(/^devices/)) {
-    totals.devices = _sumVisitsByColumn({
-      column: "device",
-      result,
-    });
-  }
-  if (result.name == "screen-size") {
-    totals.screen_resolution = _sumVisitsByColumn({
-      column: "screen_resolution",
-      result,
-    });
-  }
-  if (result.name === "os" || result.name === "os-90-days") {
-    totals.os = _sumVisitsByColumn({
-      column: "os",
-      result,
-    });
-  }
-  if (result.name === "windows" || result.name === "windows-90-days") {
-    totals.os_version = _sumVisitsByColumn({
-      column: "os_version",
-      result,
-    });
-  }
-  if (result.name === "browsers" || result.name === "browsers-90-days") {
-    totals.browser = _sumVisitsByColumn({
-      column: "browser",
-      result,
-    });
+  if (options.sumVisitsByColumns && Array.isArray(options.sumVisitsByColumns)) {
+    for (const column of options.sumVisitsByColumns) {
+      totals[`by_${column}`] = _sumVisitsByColumn({ column, result });
+    }
   }
 
   // Sum up totals with 2 levels of hashes

--- a/test/process-results/result-totals-calculator.test.js
+++ b/test/process-results/result-totals-calculator.test.js
@@ -40,6 +40,7 @@ describe("ResultTotalsCalculator", () => {
     });
 
     describe("when the report data is not empty", () => {
+      let totals;
       let report;
       let data;
 
@@ -48,432 +49,336 @@ describe("ResultTotalsCalculator", () => {
         data = Object.assign({}, dataFixture);
       });
 
-      it("should compute totals for users", () => {
-        data.metricHeaders = [{ name: "users" }];
-        data.rows = [
-          { metricValues: [{ value: "10" }] },
-          { metricValues: [{ value: "15" }] },
-          { metricValues: [{ value: "20" }] },
-        ];
+      describe('and data has the "users" metric', () => {
+        beforeEach(() => {
+          data.metricHeaders = [{ name: "users" }];
+          data.rows = [
+            { metricValues: [{ value: "10" }] },
+            { metricValues: [{ value: "15" }] },
+            { metricValues: [{ value: "20" }] },
+          ];
+          const result = analyticsDataProcessor.processData(report, data);
+          totals = ResultTotalsCalculator.calculateTotals(result);
+        });
 
-        const result = analyticsDataProcessor.processData(report, data);
-
-        const totals = ResultTotalsCalculator.calculateTotals(result);
-        expect(totals.users).to.equal(10 + 15 + 20);
+        it("computes totals for users", () => {
+          expect(totals.users).to.equal(10 + 15 + 20);
+        });
       });
 
-      it("should compute totals for visits", () => {
-        data.metricHeaders = [{ name: "sessions" }];
-        data.rows = [
-          { metricValues: [{ value: "10" }] },
-          { metricValues: [{ value: "15" }] },
-          { metricValues: [{ value: "20" }] },
-        ];
+      describe('and data has the "visits" metric', () => {
+        beforeEach(() => {
+          data.metricHeaders = [{ name: "sessions" }];
+          data.rows = [
+            { metricValues: [{ value: "10" }] },
+            { metricValues: [{ value: "15" }] },
+            { metricValues: [{ value: "20" }] },
+          ];
 
-        const result = analyticsDataProcessor.processData(report, data);
+          const result = analyticsDataProcessor.processData(report, data);
+          totals = ResultTotalsCalculator.calculateTotals(result);
+        });
 
-        const totals = ResultTotalsCalculator.calculateTotals(result);
-        expect(totals.visits).to.equal(10 + 15 + 20);
+        it("should compute totals for visits", () => {
+          expect(totals.visits).to.equal(10 + 15 + 20);
+        });
       });
 
-      it("should compute totals for device_models", () => {
-        report.name = "device_model";
-        data.dimensionHeaders = [
-          { name: "date" },
-          { name: "mobileDeviceModel" },
-        ];
-        data.metricHeaders = [{ name: "sessions" }];
-        data.rows = [
-          {
-            dimensionValues: [{ value: "20170130" }, { value: "iPhone" }],
-            metricValues: [{ value: "100" }],
-          },
-          {
-            dimensionValues: [{ value: "20170130" }, { value: "Android" }],
-            metricValues: [{ value: "200" }],
-          },
-          {
-            dimensionValues: [{ value: "20170131" }, { value: "iPhone" }],
-            metricValues: [{ value: "300" }],
-          },
-          {
-            dimensionValues: [{ value: "20170131" }, { value: "Android" }],
-            metricValues: [{ value: "400" }],
-          },
-        ];
+      describe("and options.sumVisitsByColumns is provided", () => {
+        let options;
 
-        const result = analyticsDataProcessor.processData(report, data);
+        describe("and there is one column being totalled", () => {
+          beforeEach(() => {
+            options = { sumVisitsByColumns: ["device"] };
+            report.name = "devices";
+            data.dimensionHeaders = [
+              { name: "date" },
+              { name: "deviceCategory" },
+            ];
+            data.metricHeaders = [{ name: "sessions" }];
+            data.rows = [
+              {
+                dimensionValues: [{ value: "20170130" }, { value: "mobile" }],
+                metricValues: [{ value: "100" }],
+              },
+              {
+                dimensionValues: [{ value: "20170130" }, { value: "tablet" }],
+                metricValues: [{ value: "200" }],
+              },
+              {
+                dimensionValues: [{ value: "20170130" }, { value: "desktop" }],
+                metricValues: [{ value: "300" }],
+              },
+              {
+                dimensionValues: [{ value: "20170131" }, { value: "mobile" }],
+                metricValues: [{ value: "400" }],
+              },
+              {
+                dimensionValues: [{ value: "20170131" }, { value: "tablet" }],
+                metricValues: [{ value: "500" }],
+              },
+              {
+                dimensionValues: [{ value: "20170131" }, { value: "desktop" }],
+                metricValues: [{ value: "600" }],
+              },
+            ];
 
-        const totals = ResultTotalsCalculator.calculateTotals(result);
-        expect(totals.device_models.iPhone).to.equal(100 + 300);
-        expect(totals.device_models.Android).to.equal(200 + 400);
+            const result = analyticsDataProcessor.processData(report, data);
+            totals = ResultTotalsCalculator.calculateTotals(result, options);
+          });
+
+          it("should compute totals for mobile devices", () => {
+            expect(totals.by_device.mobile).to.equal(100 + 400);
+          });
+
+          it("should compute totals for tablet devices", () => {
+            expect(totals.by_device.tablet).to.equal(200 + 500);
+          });
+
+          it("should compute totals for desktop devices", () => {
+            expect(totals.by_device.desktop).to.equal(300 + 600);
+          });
+        });
+
+        describe("and there are multiple columns being totalled", () => {
+          beforeEach(() => {
+            options = { sumVisitsByColumns: ["language", "language_code"] };
+            report.name = "language";
+            data.dimensionHeaders = [
+              { name: "date" },
+              { name: "language" },
+              { name: "language_code" },
+            ];
+            data.metricHeaders = [{ name: "sessions" }];
+            data.rows = [
+              {
+                dimensionValues: [
+                  { value: "20170130" },
+                  { value: "en" },
+                  { value: "en-us" },
+                ],
+                metricValues: [{ value: "100" }],
+              },
+              {
+                dimensionValues: [
+                  { value: "20170130" },
+                  { value: "es" },
+                  { value: "es-us" },
+                ],
+                metricValues: [{ value: "200" }],
+              },
+              {
+                dimensionValues: [
+                  { value: "20170131" },
+                  { value: "en" },
+                  { value: "en-us" },
+                ],
+                metricValues: [{ value: "300" }],
+              },
+              {
+                dimensionValues: [
+                  { value: "20170131" },
+                  { value: "es" },
+                  { value: "es-us" },
+                ],
+                metricValues: [{ value: "400" }],
+              },
+            ];
+
+            const result = analyticsDataProcessor.processData(report, data);
+            totals = ResultTotalsCalculator.calculateTotals(result, options);
+          });
+
+          it("should compute totals for en language", () => {
+            expect(totals.by_language.en).to.equal(100 + 300);
+          });
+
+          it("should compute totals for es language", () => {
+            expect(totals.by_language.es).to.equal(200 + 400);
+          });
+
+          it("should compute totals for en-us language code", () => {
+            expect(totals.by_language_code["en-us"]).to.equal(100 + 300);
+          });
+
+          it("should compute totals for es-us language code", () => {
+            expect(totals.by_language_code["es-us"]).to.equal(200 + 400);
+          });
+        });
       });
 
-      it("should compute totals for languages", () => {
-        report.name = "language";
-        data.dimensionHeaders = [{ name: "date" }, { name: "language" }];
-        data.metricHeaders = [{ name: "sessions" }];
-        data.rows = [
-          {
-            dimensionValues: [{ value: "20170130" }, { value: "en" }],
-            metricValues: [{ value: "100" }],
-          },
-          {
-            dimensionValues: [{ value: "20170130" }, { value: "es" }],
-            metricValues: [{ value: "200" }],
-          },
-          {
-            dimensionValues: [{ value: "20170131" }, { value: "en" }],
-            metricValues: [{ value: "300" }],
-          },
-          {
-            dimensionValues: [{ value: "20170131" }, { value: "es" }],
-            metricValues: [{ value: "400" }],
-          },
-        ];
+      describe("and report should sum visits for a combination of columns", () => {
+        it("should compute totals for os-browsers by operating system and browser", () => {
+          report.name = "os-browsers";
+          data.dimensionHeaders = [
+            { name: "date" },
+            { name: "operatingSystem" },
+            { name: "browser" },
+          ];
+          data.metricHeaders = [{ name: "sessions" }];
+          data.rows = [
+            {
+              dimensionValues: [
+                { value: "20170130" },
+                { value: "Windows" },
+                { value: "Chrome" },
+              ],
+              metricValues: [{ value: "100" }],
+            },
+            {
+              dimensionValues: [
+                { value: "20170130" },
+                { value: "Windows" },
+                { value: "Firefox" },
+              ],
+              metricValues: [{ value: "200" }],
+            },
+            {
+              dimensionValues: [
+                { value: "20170130" },
+                { value: "Linux" },
+                { value: "Chrome" },
+              ],
+              metricValues: [{ value: "300" }],
+            },
+            {
+              dimensionValues: [
+                { value: "20170130" },
+                { value: "Linux" },
+                { value: "Firefox" },
+              ],
+              metricValues: [{ value: "400" }],
+            },
+            {
+              dimensionValues: [
+                { value: "20170130" },
+                { value: "Windows" },
+                { value: "Chrome" },
+              ],
+              metricValues: [{ value: "500" }],
+            },
+            {
+              dimensionValues: [
+                { value: "20170130" },
+                { value: "Windows" },
+                { value: "Firefox" },
+              ],
+              metricValues: [{ value: "600" }],
+            },
+            {
+              dimensionValues: [
+                { value: "20170130" },
+                { value: "Linux" },
+                { value: "Chrome" },
+              ],
+              metricValues: [{ value: "700" }],
+            },
+            {
+              dimensionValues: [
+                { value: "20170130" },
+                { value: "Linux" },
+                { value: "Firefox" },
+              ],
+              metricValues: [{ value: "800" }],
+            },
+          ];
 
-        const result = analyticsDataProcessor.processData(report, data);
+          const result = analyticsDataProcessor.processData(report, data);
 
-        const totals = ResultTotalsCalculator.calculateTotals(result);
-        expect(totals.languages.en).to.equal(100 + 300);
-        expect(totals.languages.es).to.equal(200 + 400);
-      });
+          const totals = ResultTotalsCalculator.calculateTotals(result);
 
-      it("should compute totals for devices", () => {
-        report.name = "devices";
-        data.dimensionHeaders = [{ name: "date" }, { name: "deviceCategory" }];
-        data.metricHeaders = [{ name: "sessions" }];
-        data.rows = [
-          {
-            dimensionValues: [{ value: "20170130" }, { value: "mobile" }],
-            metricValues: [{ value: "100" }],
-          },
-          {
-            dimensionValues: [{ value: "20170130" }, { value: "tablet" }],
-            metricValues: [{ value: "200" }],
-          },
-          {
-            dimensionValues: [{ value: "20170130" }, { value: "desktop" }],
-            metricValues: [{ value: "300" }],
-          },
-          {
-            dimensionValues: [{ value: "20170131" }, { value: "mobile" }],
-            metricValues: [{ value: "400" }],
-          },
-          {
-            dimensionValues: [{ value: "20170131" }, { value: "tablet" }],
-            metricValues: [{ value: "500" }],
-          },
-          {
-            dimensionValues: [{ value: "20170131" }, { value: "desktop" }],
-            metricValues: [{ value: "600" }],
-          },
-        ];
+          expect(totals.by_os.Windows.Chrome).to.equal(100 + 500);
+          expect(totals.by_os.Windows.Firefox).to.equal(200 + 600);
 
-        const result = analyticsDataProcessor.processData(report, data);
+          expect(totals.by_browsers.Chrome.Windows).to.equal(100 + 500);
+          expect(totals.by_browsers.Chrome.Linux).to.equal(300 + 700);
+        });
 
-        const totals = ResultTotalsCalculator.calculateTotals(result);
-        expect(totals.devices.mobile).to.equal(100 + 400);
-        expect(totals.devices.tablet).to.equal(200 + 500);
-        expect(totals.devices.desktop).to.equal(300 + 600);
-      });
+        it("should compute totals for windows-browsers by windows version and browser version", () => {
+          report.name = "windows-browsers";
+          data.dimensionHeaders = [
+            { name: "date" },
+            { name: "operatingSystemVersion" },
+            { name: "browser" },
+          ];
+          data.metricHeaders = [{ name: "sessions" }];
+          data.rows = [
+            {
+              dimensionValues: [
+                { value: "20170130" },
+                { value: "XP" },
+                { value: "Chrome" },
+              ],
+              metricValues: [{ value: "100" }],
+            },
+            {
+              dimensionValues: [
+                { value: "20170130" },
+                { value: "XP" },
+                { value: "Firefox" },
+              ],
+              metricValues: [{ value: "200" }],
+            },
+            {
+              dimensionValues: [
+                { value: "20170130" },
+                { value: "Vista" },
+                { value: "Chrome" },
+              ],
+              metricValues: [{ value: "300" }],
+            },
+            {
+              dimensionValues: [
+                { value: "20170130" },
+                { value: "Vista" },
+                { value: "Firefox" },
+              ],
+              metricValues: [{ value: "400" }],
+            },
+            {
+              dimensionValues: [
+                { value: "20170130" },
+                { value: "XP" },
+                { value: "Chrome" },
+              ],
+              metricValues: [{ value: "500" }],
+            },
+            {
+              dimensionValues: [
+                { value: "20170130" },
+                { value: "XP" },
+                { value: "Firefox" },
+              ],
+              metricValues: [{ value: "600" }],
+            },
+            {
+              dimensionValues: [
+                { value: "20170130" },
+                { value: "Vista" },
+                { value: "Chrome" },
+              ],
+              metricValues: [{ value: "700" }],
+            },
+            {
+              dimensionValues: [
+                { value: "20170130" },
+                { value: "Vista" },
+                { value: "Firefox" },
+              ],
+              metricValues: [{ value: "800" }],
+            },
+          ];
 
-      it("should compute totals for screen-sizes", () => {
-        report.name = "screen-size";
-        data.dimensionHeaders = [
-          { name: "date" },
-          { name: "screenResolution" },
-        ];
-        data.metricHeaders = [{ name: "sessions" }];
-        data.rows = [
-          {
-            dimensionValues: [{ value: "20170130" }, { value: "100x100" }],
-            metricValues: [{ value: "100" }],
-          },
-          {
-            dimensionValues: [{ value: "20170130" }, { value: "200x200" }],
-            metricValues: [{ value: "200" }],
-          },
-          {
-            dimensionValues: [{ value: "20170131" }, { value: "100x100" }],
-            metricValues: [{ value: "300" }],
-          },
-          {
-            dimensionValues: [{ value: "20170131" }, { value: "200x200" }],
-            metricValues: [{ value: "400" }],
-          },
-        ];
+          const result = analyticsDataProcessor.processData(report, data);
 
-        const result = analyticsDataProcessor.processData(report, data);
+          const totals = ResultTotalsCalculator.calculateTotals(result);
 
-        const totals = ResultTotalsCalculator.calculateTotals(result);
-        expect(totals.screen_resolution["100x100"]).to.equal(100 + 300);
-        expect(totals.screen_resolution["200x200"]).to.equal(200 + 400);
-      });
+          expect(totals.by_windows.XP.Chrome).to.equal(100 + 500);
+          expect(totals.by_windows.XP.Firefox).to.equal(200 + 600);
 
-      it("should compute totals for os", () => {
-        report.name = "os";
-        data.dimensionHeaders = [{ name: "date" }, { name: "operatingSystem" }];
-        data.metricHeaders = [{ name: "sessions" }];
-        data.rows = [
-          {
-            dimensionValues: [{ value: "20170130" }, { value: "Nintendo Wii" }],
-            metricValues: [{ value: "100" }],
-          },
-          {
-            dimensionValues: [{ value: "20170130" }, { value: "Xbox" }],
-            metricValues: [{ value: "200" }],
-          },
-          {
-            dimensionValues: [{ value: "20170131" }, { value: "Nintendo Wii" }],
-            metricValues: [{ value: "300" }],
-          },
-          {
-            dimensionValues: [{ value: "20170131" }, { value: "Xbox" }],
-            metricValues: [{ value: "400" }],
-          },
-        ];
-
-        const result = analyticsDataProcessor.processData(report, data);
-
-        const totals = ResultTotalsCalculator.calculateTotals(result);
-        expect(totals.os["Nintendo Wii"]).to.equal(100 + 300);
-        expect(totals.os["Xbox"]).to.equal(200 + 400);
-      });
-
-      it("should compute totals for windows", () => {
-        report.name = "windows";
-        data.dimensionHeaders = [
-          { name: "date" },
-          { name: "operatingSystemVersion" },
-        ];
-        data.metricHeaders = [{ name: "sessions" }];
-        data.rows = [
-          {
-            dimensionValues: [{ value: "20170130" }, { value: "Server" }],
-            metricValues: [{ value: "100" }],
-          },
-          {
-            dimensionValues: [{ value: "20170130" }, { value: "Vista" }],
-            metricValues: [{ value: "200" }],
-          },
-          {
-            dimensionValues: [{ value: "20170131" }, { value: "Server" }],
-            metricValues: [{ value: "300" }],
-          },
-          {
-            dimensionValues: [{ value: "20170131" }, { value: "Vista" }],
-            metricValues: [{ value: "400" }],
-          },
-        ];
-
-        const result = analyticsDataProcessor.processData(report, data);
-
-        const totals = ResultTotalsCalculator.calculateTotals(result);
-        expect(totals.os_version.Server).to.equal(100 + 300);
-        expect(totals.os_version.Vista).to.equal(200 + 400);
-      });
-
-      it("should compute totals for browsers", () => {
-        report.name = "browsers";
-        data.dimensionHeaders = [{ name: "date" }, { name: "browser" }];
-        data.metricHeaders = [{ name: "sessions" }];
-        data.rows = [
-          {
-            dimensionValues: [{ value: "20170130" }, { value: "Chrome" }],
-            metricValues: [{ value: "100" }],
-          },
-          {
-            dimensionValues: [{ value: "20170130" }, { value: "Safari" }],
-            metricValues: [{ value: "200" }],
-          },
-          {
-            dimensionValues: [{ value: "20170131" }, { value: "Chrome" }],
-            metricValues: [{ value: "300" }],
-          },
-          {
-            dimensionValues: [{ value: "20170131" }, { value: "Safari" }],
-            metricValues: [{ value: "400" }],
-          },
-        ];
-
-        const result = analyticsDataProcessor.processData(report, data);
-
-        const totals = ResultTotalsCalculator.calculateTotals(result);
-        expect(totals.browser.Chrome).to.equal(100 + 300);
-        expect(totals.browser.Safari).to.equal(200 + 400);
-      });
-
-      it("should compute totals for os-browsers by operating system and browser", () => {
-        report.name = "os-browsers";
-        data.dimensionHeaders = [
-          { name: "date" },
-          { name: "operatingSystem" },
-          { name: "browser" },
-        ];
-        data.metricHeaders = [{ name: "sessions" }];
-        data.rows = [
-          {
-            dimensionValues: [
-              { value: "20170130" },
-              { value: "Windows" },
-              { value: "Chrome" },
-            ],
-            metricValues: [{ value: "100" }],
-          },
-          {
-            dimensionValues: [
-              { value: "20170130" },
-              { value: "Windows" },
-              { value: "Firefox" },
-            ],
-            metricValues: [{ value: "200" }],
-          },
-          {
-            dimensionValues: [
-              { value: "20170130" },
-              { value: "Linux" },
-              { value: "Chrome" },
-            ],
-            metricValues: [{ value: "300" }],
-          },
-          {
-            dimensionValues: [
-              { value: "20170130" },
-              { value: "Linux" },
-              { value: "Firefox" },
-            ],
-            metricValues: [{ value: "400" }],
-          },
-          {
-            dimensionValues: [
-              { value: "20170130" },
-              { value: "Windows" },
-              { value: "Chrome" },
-            ],
-            metricValues: [{ value: "500" }],
-          },
-          {
-            dimensionValues: [
-              { value: "20170130" },
-              { value: "Windows" },
-              { value: "Firefox" },
-            ],
-            metricValues: [{ value: "600" }],
-          },
-          {
-            dimensionValues: [
-              { value: "20170130" },
-              { value: "Linux" },
-              { value: "Chrome" },
-            ],
-            metricValues: [{ value: "700" }],
-          },
-          {
-            dimensionValues: [
-              { value: "20170130" },
-              { value: "Linux" },
-              { value: "Firefox" },
-            ],
-            metricValues: [{ value: "800" }],
-          },
-        ];
-
-        const result = analyticsDataProcessor.processData(report, data);
-
-        const totals = ResultTotalsCalculator.calculateTotals(result);
-
-        expect(totals.by_os.Windows.Chrome).to.equal(100 + 500);
-        expect(totals.by_os.Windows.Firefox).to.equal(200 + 600);
-
-        expect(totals.by_browsers.Chrome.Windows).to.equal(100 + 500);
-        expect(totals.by_browsers.Chrome.Linux).to.equal(300 + 700);
-      });
-
-      it("should compute totals for windows-browsers by windows version and browser version", () => {
-        report.name = "windows-browsers";
-        data.dimensionHeaders = [
-          { name: "date" },
-          { name: "operatingSystemVersion" },
-          { name: "browser" },
-        ];
-        data.metricHeaders = [{ name: "sessions" }];
-        data.rows = [
-          {
-            dimensionValues: [
-              { value: "20170130" },
-              { value: "XP" },
-              { value: "Chrome" },
-            ],
-            metricValues: [{ value: "100" }],
-          },
-          {
-            dimensionValues: [
-              { value: "20170130" },
-              { value: "XP" },
-              { value: "Firefox" },
-            ],
-            metricValues: [{ value: "200" }],
-          },
-          {
-            dimensionValues: [
-              { value: "20170130" },
-              { value: "Vista" },
-              { value: "Chrome" },
-            ],
-            metricValues: [{ value: "300" }],
-          },
-          {
-            dimensionValues: [
-              { value: "20170130" },
-              { value: "Vista" },
-              { value: "Firefox" },
-            ],
-            metricValues: [{ value: "400" }],
-          },
-          {
-            dimensionValues: [
-              { value: "20170130" },
-              { value: "XP" },
-              { value: "Chrome" },
-            ],
-            metricValues: [{ value: "500" }],
-          },
-          {
-            dimensionValues: [
-              { value: "20170130" },
-              { value: "XP" },
-              { value: "Firefox" },
-            ],
-            metricValues: [{ value: "600" }],
-          },
-          {
-            dimensionValues: [
-              { value: "20170130" },
-              { value: "Vista" },
-              { value: "Chrome" },
-            ],
-            metricValues: [{ value: "700" }],
-          },
-          {
-            dimensionValues: [
-              { value: "20170130" },
-              { value: "Vista" },
-              { value: "Firefox" },
-            ],
-            metricValues: [{ value: "800" }],
-          },
-        ];
-
-        const result = analyticsDataProcessor.processData(report, data);
-
-        const totals = ResultTotalsCalculator.calculateTotals(result);
-
-        expect(totals.by_windows.XP.Chrome).to.equal(100 + 500);
-        expect(totals.by_windows.XP.Firefox).to.equal(200 + 600);
-
-        expect(totals.by_browsers.Chrome.XP).to.equal(100 + 500);
-        expect(totals.by_browsers.Chrome.Vista).to.equal(300 + 700);
+          expect(totals.by_browsers.Chrome.XP).to.equal(100 + 500);
+          expect(totals.by_browsers.Chrome.Vista).to.equal(300 + 700);
+        });
       });
     });
   });


### PR DESCRIPTION
Add reports for:
- session_default_channel_group
- session_source_medium

Update totalling logic in the data processor to consider report config item sumVisitsByColumns instead of hard coding the reports to total by column. Add this config value to the reports which were being totalled already as well as the newly added reports.

Add filters to traffic sources reports for undesired source names