### PR TITLE
Add 'npm audit signatures' to CI workflow.

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -13,7 +13,7 @@ jobs:
       - name: Install node
         uses: actions/setup-node@v4
         with:
-          node-version: "lts/*"
+          node-version-file: ".nvmrc"
           cache: 'npm'
       - name: Install node dependencies
         run: npm ci
@@ -27,7 +27,7 @@ jobs:
       - name: Install node
         uses: actions/setup-node@v4
         with:
-          node-version: "lts/*"
+          node-version-file: ".nvmrc"
           cache: 'npm'
       - name: Install node dependencies
         run: npm ci
@@ -59,7 +59,7 @@ jobs:
       - name: Install node
         uses: actions/setup-node@v4
         with:
-          node-version: "lts/*"
+          node-version-file: ".nvmrc"
           cache: 'npm'
       - name: Install node dependencies
         run: npm ci
@@ -68,6 +68,7 @@ jobs:
   deploy_dev:
     needs:
       - lint
+      - audit_dependencies
       - test
     if: github.ref == 'refs/heads/develop'
     uses: 18F/analytics-reporter/.github/workflows/deploy.yml@develop
@@ -97,6 +98,7 @@ jobs:
   deploy_stg:
     needs:
       - lint
+      - audit_dependencies
       - test
     if: github.ref == 'refs/heads/staging'
     uses: 18F/analytics-reporter/.github/workflows/deploy.yml@develop
@@ -126,6 +128,7 @@ jobs:
   deploy_prd:
     needs:
       - lint
+      - audit_dependencies
       - test
     if: github.ref == 'refs/heads/master'
     uses: 18F/analytics-reporter/.github/workflows/deploy.yml@develop

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -19,8 +19,24 @@ jobs:
         run: npm ci
       - name: Lint javascript
         run: npm run lint
+  audit_dependencies:
+    runs-on: ubuntu-latest
+    steps:
+      - name: Code checkout
+        uses: actions/checkout@v4
+      - name: Install node
+        uses: actions/setup-node@v4
+        with:
+          node-version: "lts/*"
+          cache: 'npm'
+      - name: Install node dependencies
+        run: npm ci
+      - name: Validate npm package signatures
+        run: npm audit signatures
   test:
-    needs: lint
+    needs:
+      - lint
+      - audit_dependencies
     runs-on: ubuntu-latest
     # Start Postgres as a service, wait until healthy. Uses latest Postgres version.
     services:

--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -91,7 +91,7 @@ jobs:
       - name: Install node
         uses: actions/setup-node@v4
         with:
-          node-version: "lts/*"
+          node-version-file: ".nvmrc"
           cache: 'npm'
       - name: Install node dependencies
         # This causes npm install to omit dev dependencies per NPM docs.
@@ -133,7 +133,7 @@ jobs:
       - name: Install node
         uses: actions/setup-node@v4
         with:
-          node-version: "lts/*"
+          node-version-file: ".nvmrc"
           cache: 'npm'
       - name: Install node dependencies
         # This causes npm install to omit dev dependencies per NPM docs.


### PR DESCRIPTION
This PR is related to the Trello card [Implement subresource integrity for all analytics.usa.gov application components](https://trello.com/c/jQA2F0JX). npm audit signatures "verifies the registry signatures of downloaded packages" that "you download from the public npm registry, or any registry that supports signatures". It also verifies the ["provenance attestations"](https://slsa.dev/spec/v1.0/provenance) of any packages that provide them.