### PR TITLE
Revert "Temporary fix - Add filters to remove sensitive NSF URLs from public data

### DIFF
--- a/README.md
+++ b/README.md
@@ -109,7 +109,7 @@ npm run coverage
 
 The integration tests for this repo require the google analytics credentials to
 be set in the environment. This can be setup with the dotenv-cli package as
-described in "Setup Environment" section above.
+described in the [Setup Environment](#setup-environment) section.
 
 Note that these tests make real requests to google analytics APIs and should be
 run sparingly to avoid being rate limited in our live apps which use the
@@ -117,10 +117,10 @@ same account credentials.
 
 ```bash
 # Run cucumber integration tests
-dotenv -e .env npm run cucumber
+npx dotenv -- npm run cucumber
 
 # Run cucumber integration tests with node debugging enabled
-dotenv -e .env npm run cucumber:debug
+npx dotenv -- npm run cucumber:debug
 ```
 
 The cucumber features and support files can be found in the `features` directory
@@ -129,7 +129,7 @@ The cucumber features and support files can be found in the `features` directory
 
 #### Setup environment
 
-See "Configuration and Google Analytics Setup" below for the required environment variables and other setup for Google Analytics auth.
+See [Configuration - Google Analytics](#google-analytics)  for the required environment variables and other setup for Google Analytics auth.
 
 It may be easiest to use the dotenv-cli package to configure the environment for the application.
 
@@ -163,6 +163,17 @@ npx dotenv -e .env.analytics node -- deploy/publisher.js
 
 # start consumer
 npx dotenv -e .env.analytics node -- deploy/consumer.js
+```
+
+To run a single report for a specific agency, set AGENCY_NAME and ANALYTICS_REPORT_IDS in your .env file (refer to `../deploy/agencies.json`)
+and then run:
+
+```bash
+# general format
+npx dotenv -- npm start -- --only=REPORT_NAME --json --output=/path/to/output
+
+# example
+npx dotenv -- npm start -- --only=devices --json --output=./output
 ```
 
 ## Configuration

--- a/reports/usa.json
+++ b/reports/usa.json
@@ -4994,6 +4994,7 @@
                     "fieldName": "pagePath",
                     "inListFilter": {
                       "values": [
+                        "(data deleted)",
                         "(other)",
                         "other",
                         "(not set)",
@@ -5069,6 +5070,7 @@
                     "fieldName": "pagePath",
                     "inListFilter": {
                       "values": [
+                        "(data deleted)",
                         "(other)",
                         "other",
                         "(not set)",
@@ -5144,6 +5146,7 @@
                     "fieldName": "pagePath",
                     "inListFilter": {
                       "values": [
+                        "(data deleted)",
                         "(other)",
                         "other",
                         "(not set)",
@@ -5219,6 +5222,7 @@
                     "fieldName": "pagePath",
                     "inListFilter": {
                       "values": [
+                        "(data deleted)",
                         "(other)",
                         "other",
                         "(not set)",
@@ -5294,6 +5298,7 @@
                     "fieldName": "pagePath",
                     "inListFilter": {
                       "values": [
+                        "(data deleted)",
                         "(other)",
                         "other",
                         "(not set)",
@@ -5369,6 +5374,7 @@
                     "fieldName": "pagePath",
                     "inListFilter": {
                       "values": [
+                        "(data deleted)",
                         "(other)",
                         "other",
                         "(not set)",
@@ -5444,6 +5450,7 @@
                     "fieldName": "pagePath",
                     "inListFilter": {
                       "values": [
+                        "(data deleted)",
                         "(other)",
                         "other",
                         "(not set)",
@@ -5519,6 +5526,7 @@
                     "fieldName": "pagePath",
                     "inListFilter": {
                       "values": [
+                        "(data deleted)",
                         "(other)",
                         "other",
                         "(not set)",
@@ -5594,6 +5602,7 @@
                     "fieldName": "pagePath",
                     "inListFilter": {
                       "values": [
+                        "(data deleted)",
                         "(other)",
                         "other",
                         "(not set)",
@@ -5669,6 +5678,7 @@
                     "fieldName": "pagePath",
                     "inListFilter": {
                       "values": [
+                        "(data deleted)",
                         "(other)",
                         "other",
                         "(not set)",
@@ -5744,6 +5754,7 @@
                     "fieldName": "pagePath",
                     "inListFilter": {
                       "values": [
+                        "(data deleted)",
                         "(other)",
                         "other",
                         "(not set)",
@@ -5819,6 +5830,7 @@
                     "fieldName": "pagePath",
                     "inListFilter": {
                       "values": [
+                        "(data deleted)",
                         "(other)",
                         "other",
                         "(not set)",
@@ -5894,6 +5906,7 @@
                     "fieldName": "pagePath",
                     "inListFilter": {
                       "values": [
+                        "(data deleted)",
                         "(other)",
                         "other",
                         "(not set)",
@@ -5969,6 +5982,7 @@
                     "fieldName": "pagePath",
                     "inListFilter": {
                       "values": [
+                        "(data deleted)",
                         "(other)",
                         "other",
                         "(not set)",
@@ -6044,6 +6058,7 @@
                     "fieldName": "pagePath",
                     "inListFilter": {
                       "values": [
+                        "(data deleted)",
                         "(other)",
                         "other",
                         "(not set)",
@@ -6119,6 +6134,7 @@
                     "fieldName": "pagePath",
                     "inListFilter": {
                       "values": [
+                        "(data deleted)",
                         "(other)",
                         "other",
                         "(not set)",
@@ -6176,6 +6192,26 @@
         "dimensionFilter": {
           "andGroup": {
             "expressions": [
+              {
+                "notExpression": {
+                  "filter": {
+                    "fieldName": "pagePath",
+                    "stringFilter": {
+                      "inListFilter": {
+                        "values": [
+                          "(data deleted)",
+                          "(other)",
+                          "other",
+                          "(not set)",
+                          "null",
+                          ""
+                        ],
+                        "caseSensitive": false
+                      }
+                    }
+                  }
+                }
+              },
               {
                 "notExpression": {
                   "filter": {

--- a/reports/usa.json
+++ b/reports/usa.json
@@ -4973,34 +4973,6 @@
             "expressions": [
               {
                 "notExpression": {
-                  "andGroup": {
-                    "expressions": [
-                      {
-                        "filter": {
-                          "fieldName": "hostName",
-                          "stringFilter": {
-                            "matchType": "EXACT",
-                            "value": "etap.nsf.gov",
-                            "caseSensitive": false
-                          }
-                        }
-                      },
-                      {
-                        "filter": {
-                          "fieldName": "pagePath",
-                          "stringFilter": {
-                            "matchType": "BEGINS_WITH",
-                            "value": "/reference-writer",
-                            "caseSensitive": false
-                          }
-                        }
-                      }
-                    ]
-                  }
-                }
-              },
-              {
-                "notExpression": {
                   "filter": {
                     "fieldName": "hostName",
                     "inListFilter": {
@@ -5074,34 +5046,6 @@
         "dimensionFilter": {
           "andGroup": {
             "expressions": [
-              {
-                "notExpression": {
-                  "andGroup": {
-                    "expressions": [
-                      {
-                        "filter": {
-                          "fieldName": "hostName",
-                          "stringFilter": {
-                            "matchType": "EXACT",
-                            "value": "etap.nsf.gov",
-                            "caseSensitive": false
-                          }
-                        }
-                      },
-                      {
-                        "filter": {
-                          "fieldName": "pagePath",
-                          "stringFilter": {
-                            "matchType": "BEGINS_WITH",
-                            "value": "/reference-writer",
-                            "caseSensitive": false
-                          }
-                        }
-                      }
-                    ]
-                  }
-                }
-              },
               {
                 "notExpression": {
                   "filter": {
@@ -5179,34 +5123,6 @@
             "expressions": [
               {
                 "notExpression": {
-                  "andGroup": {
-                    "expressions": [
-                      {
-                        "filter": {
-                          "fieldName": "hostName",
-                          "stringFilter": {
-                            "matchType": "EXACT",
-                            "value": "etap.nsf.gov",
-                            "caseSensitive": false
-                          }
-                        }
-                      },
-                      {
-                        "filter": {
-                          "fieldName": "pagePath",
-                          "stringFilter": {
-                            "matchType": "BEGINS_WITH",
-                            "value": "/reference-writer",
-                            "caseSensitive": false
-                          }
-                        }
-                      }
-                    ]
-                  }
-                }
-              },
-              {
-                "notExpression": {
                   "filter": {
                     "fieldName": "hostName",
                     "inListFilter": {
@@ -5280,34 +5196,6 @@
         "dimensionFilter": {
           "andGroup": {
             "expressions": [
-              {
-                "notExpression": {
-                  "andGroup": {
-                    "expressions": [
-                      {
-                        "filter": {
-                          "fieldName": "hostName",
-                          "stringFilter": {
-                            "matchType": "EXACT",
-                            "value": "etap.nsf.gov",
-                            "caseSensitive": false
-                          }
-                        }
-                      },
-                      {
-                        "filter": {
-                          "fieldName": "pagePath",
-                          "stringFilter": {
-                            "matchType": "BEGINS_WITH",
-                            "value": "/reference-writer",
-                            "caseSensitive": false
-                          }
-                        }
-                      }
-                    ]
-                  }
-                }
-              },
               {
                 "notExpression": {
                   "filter": {
@@ -5385,34 +5273,6 @@
             "expressions": [
               {
                 "notExpression": {
-                  "andGroup": {
-                    "expressions": [
-                      {
-                        "filter": {
-                          "fieldName": "hostName",
-                          "stringFilter": {
-                            "matchType": "EXACT",
-                            "value": "etap.nsf.gov",
-                            "caseSensitive": false
-                          }
-                        }
-                      },
-                      {
-                        "filter": {
-                          "fieldName": "pagePath",
-                          "stringFilter": {
-                            "matchType": "BEGINS_WITH",
-                            "value": "/reference-writer",
-                            "caseSensitive": false
-                          }
-                        }
-                      }
-                    ]
-                  }
-                }
-              },
-              {
-                "notExpression": {
                   "filter": {
                     "fieldName": "hostName",
                     "inListFilter": {
@@ -5486,34 +5346,6 @@
         "dimensionFilter": {
           "andGroup": {
             "expressions": [
-              {
-                "notExpression": {
-                  "andGroup": {
-                    "expressions": [
-                      {
-                        "filter": {
-                          "fieldName": "hostName",
-                          "stringFilter": {
-                            "matchType": "EXACT",
-                            "value": "etap.nsf.gov",
-                            "caseSensitive": false
-                          }
-                        }
-                      },
-                      {
-                        "filter": {
-                          "fieldName": "pagePath",
-                          "stringFilter": {
-                            "matchType": "BEGINS_WITH",
-                            "value": "/reference-writer",
-                            "caseSensitive": false
-                          }
-                        }
-                      }
-                    ]
-                  }
-                }
-              },
               {
                 "notExpression": {
                   "filter": {
@@ -5591,34 +5423,6 @@
             "expressions": [
               {
                 "notExpression": {
-                  "andGroup": {
-                    "expressions": [
-                      {
-                        "filter": {
-                          "fieldName": "hostName",
-                          "stringFilter": {
-                            "matchType": "EXACT",
-                            "value": "etap.nsf.gov",
-                            "caseSensitive": false
-                          }
-                        }
-                      },
-                      {
-                        "filter": {
-                          "fieldName": "pagePath",
-                          "stringFilter": {
-                            "matchType": "BEGINS_WITH",
-                            "value": "/reference-writer",
-                            "caseSensitive": false
-                          }
-                        }
-                      }
-                    ]
-                  }
-                }
-              },
-              {
-                "notExpression": {
                   "filter": {
                     "fieldName": "hostName",
                     "inListFilter": {
@@ -5692,34 +5496,6 @@
         "dimensionFilter": {
           "andGroup": {
             "expressions": [
-              {
-                "notExpression": {
-                  "andGroup": {
-                    "expressions": [
-                      {
-                        "filter": {
-                          "fieldName": "hostName",
-                          "stringFilter": {
-                            "matchType": "EXACT",
-                            "value": "etap.nsf.gov",
-                            "caseSensitive": false
-                          }
-                        }
-                      },
-                      {
-                        "filter": {
-                          "fieldName": "pagePath",
-                          "stringFilter": {
-                            "matchType": "BEGINS_WITH",
-                            "value": "/reference-writer",
-                            "caseSensitive": false
-                          }
-                        }
-                      }
-                    ]
-                  }
-                }
-              },
               {
                 "notExpression": {
                   "filter": {
@@ -5797,34 +5573,6 @@
             "expressions": [
               {
                 "notExpression": {
-                  "andGroup": {
-                    "expressions": [
-                      {
-                        "filter": {
-                          "fieldName": "hostName",
-                          "stringFilter": {
-                            "matchType": "EXACT",
-                            "value": "etap.nsf.gov",
-                            "caseSensitive": false
-                          }
-                        }
-                      },
-                      {
-                        "filter": {
-                          "fieldName": "pagePath",
-                          "stringFilter": {
-                            "matchType": "BEGINS_WITH",
-                            "value": "/reference-writer",
-                            "caseSensitive": false
-                          }
-                        }
-                      }
-                    ]
-                  }
-                }
-              },
-              {
-                "notExpression": {
                   "filter": {
                     "fieldName": "hostName",
                     "inListFilter": {
@@ -5898,34 +5646,6 @@
         "dimensionFilter": {
           "andGroup": {
             "expressions": [
-              {
-                "notExpression": {
-                  "andGroup": {
-                    "expressions": [
-                      {
-                        "filter": {
-                          "fieldName": "hostName",
-                          "stringFilter": {
-                            "matchType": "EXACT",
-                            "value": "etap.nsf.gov",
-                            "caseSensitive": false
-                          }
-                        }
-                      },
-                      {
-                        "filter": {
-                          "fieldName": "pagePath",
-                          "stringFilter": {
-                            "matchType": "BEGINS_WITH",
-                            "value": "/reference-writer",
-                            "caseSensitive": false
-                          }
-                        }
-                      }
-                    ]
-                  }
-                }
-              },
               {
                 "notExpression": {
                   "filter": {
@@ -6003,34 +5723,6 @@
             "expressions": [
               {
                 "notExpression": {
-                  "andGroup": {
-                    "expressions": [
-                      {
-                        "filter": {
-                          "fieldName": "hostName",
-                          "stringFilter": {
-                            "matchType": "EXACT",
-                            "value": "etap.nsf.gov",
-                            "caseSensitive": false
-                          }
-                        }
-                      },
-                      {
-                        "filter": {
-                          "fieldName": "pagePath",
-                          "stringFilter": {
-                            "matchType": "BEGINS_WITH",
-                            "value": "/reference-writer",
-                            "caseSensitive": false
-                          }
-                        }
-                      }
-                    ]
-                  }
-                }
-              },
-              {
-                "notExpression": {
                   "filter": {
                     "fieldName": "hostName",
                     "inListFilter": {
@@ -6104,34 +5796,6 @@
         "dimensionFilter": {
           "andGroup": {
             "expressions": [
-              {
-                "notExpression": {
-                  "andGroup": {
-                    "expressions": [
-                      {
-                        "filter": {
-                          "fieldName": "hostName",
-                          "stringFilter": {
-                            "matchType": "EXACT",
-                            "value": "etap.nsf.gov",
-                            "caseSensitive": false
-                          }
-                        }
-                      },
-                      {
-                        "filter": {
-                          "fieldName": "pagePath",
-                          "stringFilter": {
-                            "matchType": "BEGINS_WITH",
-                            "value": "/reference-writer",
-                            "caseSensitive": false
-                          }
-                        }
-                      }
-                    ]
-                  }
-                }
-              },
               {
                 "notExpression": {
                   "filter": {
@@ -6209,34 +5873,6 @@
             "expressions": [
               {
                 "notExpression": {
-                  "andGroup": {
-                    "expressions": [
-                      {
-                        "filter": {
-                          "fieldName": "hostName",
-                          "stringFilter": {
-                            "matchType": "EXACT",
-                            "value": "etap.nsf.gov",
-                            "caseSensitive": false
-                          }
-                        }
-                      },
-                      {
-                        "filter": {
-                          "fieldName": "pagePath",
-                          "stringFilter": {
-                            "matchType": "BEGINS_WITH",
-                            "value": "/reference-writer",
-                            "caseSensitive": false
-                          }
-                        }
-                      }
-                    ]
-                  }
-                }
-              },
-              {
-                "notExpression": {
                   "filter": {
                     "fieldName": "hostName",
                     "inListFilter": {
@@ -6310,34 +5946,6 @@
         "dimensionFilter": {
           "andGroup": {
             "expressions": [
-              {
-                "notExpression": {
-                  "andGroup": {
-                    "expressions": [
-                      {
-                        "filter": {
-                          "fieldName": "hostName",
-                          "stringFilter": {
-                            "matchType": "EXACT",
-                            "value": "etap.nsf.gov",
-                            "caseSensitive": false
-                          }
-                        }
-                      },
-                      {
-                        "filter": {
-                          "fieldName": "pagePath",
-                          "stringFilter": {
-                            "matchType": "BEGINS_WITH",
-                            "value": "/reference-writer",
-                            "caseSensitive": false
-                          }
-                        }
-                      }
-                    ]
-                  }
-                }
-              },
               {
                 "notExpression": {
                   "filter": {
@@ -6415,34 +6023,6 @@
             "expressions": [
               {
                 "notExpression": {
-                  "andGroup": {
-                    "expressions": [
-                      {
-                        "filter": {
-                          "fieldName": "hostName",
-                          "stringFilter": {
-                            "matchType": "EXACT",
-                            "value": "etap.nsf.gov",
-                            "caseSensitive": false
-                          }
-                        }
-                      },
-                      {
-                        "filter": {
-                          "fieldName": "pagePath",
-                          "stringFilter": {
-                            "matchType": "BEGINS_WITH",
-                            "value": "/reference-writer",
-                            "caseSensitive": false
-                          }
-                        }
-                      }
-                    ]
-                  }
-                }
-              },
-              {
-                "notExpression": {
                   "filter": {
                     "fieldName": "hostName",
                     "inListFilter": {
@@ -6516,34 +6096,6 @@
         "dimensionFilter": {
           "andGroup": {
             "expressions": [
-              {
-                "notExpression": {
-                  "andGroup": {
-                    "expressions": [
-                      {
-                        "filter": {
-                          "fieldName": "hostName",
-                          "stringFilter": {
-                            "matchType": "EXACT",
-                            "value": "etap.nsf.gov",
-                            "caseSensitive": false
-                          }
-                        }
-                      },
-                      {
-                        "filter": {
-                          "fieldName": "pagePath",
-                          "stringFilter": {
-                            "matchType": "BEGINS_WITH",
-                            "value": "/reference-writer",
-                            "caseSensitive": false
-                          }
-                        }
-                      }
-                    ]
-                  }
-                }
-              },
               {
                 "notExpression": {
                   "filter": {
@@ -6624,34 +6176,6 @@
         "dimensionFilter": {
           "andGroup": {
             "expressions": [
-              {
-                "notExpression": {
-                  "andGroup": {
-                    "expressions": [
-                      {
-                        "filter": {
-                          "fieldName": "hostName",
-                          "stringFilter": {
-                            "matchType": "EXACT",
-                            "value": "etap.nsf.gov",
-                            "caseSensitive": false
-                          }
-                        }
-                      },
-                      {
-                        "filter": {
-                          "fieldName": "pagePath",
-                          "stringFilter": {
-                            "matchType": "BEGINS_WITH",
-                            "value": "/reference-writer",
-                            "caseSensitive": false
-                          }
-                        }
-                      }
-                    ]
-                  }
-                }
-              },
               {
                 "notExpression": {
                   "filter": {


### PR DESCRIPTION
This reverts commit c72b7779f836ac430e4bb487223413cd3af05825.

The sensitive data has been redacted in Google Analytics (via a data deletion request) so it is safe to remove the filters that were put in place to block the sensitive data from being exported from GA to the public reports. I did add some `(data deleted)` dimension filters to prevent export of the redacted fields - not for security reasons, just to keep the data reported in analytics.usa.gov clean and non-confusing.

If you have permission to view draft security advisories in this repo, you can see more details there.