### PR TITLE
Bump reporter disk quota to 1GB to accomodate updated npm dependencies

### DIFF
--- a/manifest.consumer.yml
+++ b/manifest.consumer.yml
@@ -5,7 +5,7 @@ applications:
   # parallel. This could be reduced if we limited the number of simultaneous
   # processes.
   memory: 416M
-  disk_quota: 512M
+  disk_quota: 1G
   health-check-type: process
   buildpacks:
   - nodejs_buildpack

--- a/manifest.publisher.yml
+++ b/manifest.publisher.yml
@@ -5,7 +5,7 @@ applications:
   # parallel. This could be reduced if we limited the number of simultaneous
   # processes.
   memory: 192M
-  disk_quota: 512M
+  disk_quota: 1G
   health-check-type: process
   buildpacks:
   - nodejs_buildpack


### PR DESCRIPTION
https://github.com/18F/analytics-reporter/pull/1018 updated npm dependencies to fix a critical security finding. The updated dependencies increased the size of the consumer/publisher apps a bit and pushed them over their current disk quotas in Cloud.gov. 

Actual disk size before change: 460 MB of a 512 MB quota
Actual disk size after change: 539 MB

I see no obvious candidates for reducing the app size and 1GB is still less than the default disk quota on Cloud.gov, so I'm going to bump up the quota.