### PR TITLE
Send new relic logs to stdout

### DIFF
--- a/newrelic.js
+++ b/newrelic.js
@@ -3,5 +3,6 @@ exports.config = {
   license_key: process.env.NEW_RELIC_LICENSE_KEY,
   logging: {
     level: "info",
+    filepath: "stdout",
   },
 };


### PR DESCRIPTION
NewRelic logs are written to file by default, not to stdout, which means they don't show up in the cloud.gov log streams. That makes it hard to debug NewRelic problems. This PR configures the logs to go to stdout.