### PR TITLE
Fix grammar error and copy-paste bug in JSDoc comments

### DIFF
--- a/src/process_results/result_formatter.js
+++ b/src/process_results/result_formatter.js
@@ -13,7 +13,7 @@ const csv = require("fast-csv");
  * @param {object} result an analytics object to be formatted.
  * @param {object} config optional configuration for the formatter.
  * @param {string} config.format the format to output can be "json" or "csv"
- * @param {boolean} config.slim whether the result should have it's data field
+ * @param {boolean} config.slim whether the result should have its data field
  * removed from the result of formatting (only for JSON format).
  * @returns {string} a JSON string or a CSV string depending on passed params.
  */

--- a/src/process_results/result_totals_calculator.js
+++ b/src/process_results/result_totals_calculator.js
@@ -7,7 +7,7 @@
  * @param {string[]} options.sumActiveUsersByDimensions an array of columns to
  * be totalled by the number of active users for each unique key in the column.
  * @param {string[]} options.sumTotalUsersByDimensions an array of columns to
- * be totalled by the number of active users for each unique key in the column.
+ * be totalled by the number of total users for each unique key in the column.
  * @param {string[]} options.sumTotalEventsByDimensions an array of columns to
  * be totalled by the number of total events for each unique key in the column.
  * @returns {object} totals for the results.


### PR DESCRIPTION
## Summary
- Fix `it's` → `its` (possessive) in result_formatter.js JSDoc
- Fix copy-paste error in result_totals_calculator.js JSDoc — description said "active users" instead of "total users" for `sumTotalUsersByDimensions`

Comments only — no functional changes.