### PR TITLE
Remove stray root newrelic dependency from lockfile

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -19,7 +19,6 @@
         "googleapis": "^140.0.0",
         "max-listeners-exceeded-warning": "^0.0.1",
         "minimist": "^1.2.8",
-        "newrelic": "14.1.1",
         "p-retry": "^6.2.0",
         "pg-boss": "^9.0.3",
         "proxy-agent": "^6.4.0",


### PR DESCRIPTION
## Context
The staging branch's `package-lock.json` carried a stray root `dependencies` entry `"newrelic": "14.1.1"` at line 22. Commit `0acdcc7` ("Forgot to update lock file (#1088)") had removed this line on `develop`, but the staging-only merge commit `d1d6371` ("Merge pull request #1089 from 18F/develop") re-resolved the lockfile incorrectly during conflict resolution and reintroduced the line. As a result staging's lockfile diverged from develop.

## Plan
- Restore `package-lock.json` on this branch to match develop's correct version (single-line deletion).
- Retain the legitimate `optionalDependencies.newrelic` entry, which matches `package.json`.

## Verification
- `git diff develop -- package-lock.json` → no differences (staging lockfile now matches develop).
- Lockfile consistency check:
  - `packages[""].dependencies.newrelic` → `undefined` (removed)
  - `packages[""].optionalDependencies.newrelic` → `^14.1.1` (retained, matches package.json)
  - `node_modules/newrelic` resolution → present
- Change is a single-line deletion:
  ```
  -        "newrelic": "14.1.1",
  ```

## Rollback
Revert this PR's commit (`git revert 0e8398d`) or re-add the line to `package-lock.json` root dependencies.

## Security Impact
None. Removes a duplicate/incorrect dependency declaration from the lockfile. No change to authentication, authorization, data handling, or attack surface.

Co-authored-by: OpenCode Agent <shelley.nason@gsa.gov>