### PR TITLE
Fix start_date and end_date never being set in calculated totals

### DIFF
--- a/src/process_results/result_totals_calculator.js
+++ b/src/process_results/result_totals_calculator.js
@@ -126,9 +126,9 @@ const calculateTotals = (result, options = {}) => {
   }
 
   // Set the start and end date
-  if (result.data[0].data) {
+  if (result.data[0].date) {
     // Occasionally we'll get bogus start dates
-    if (result.date[0].date === "(other)") {
+    if (result.data[0].date === "(other)") {
       totalledResult.start_date = result.data[1].date;
     } else {
       totalledResult.start_date = result.data[0].date;

--- a/test/actions/query_google_analytics.test.js
+++ b/test/actions/query_google_analytics.test.js
@@ -276,6 +276,8 @@ describe("QueryGoogleAnalytics", () => {
         activeUsers: 2400,
         totalUsers: 2400,
         visits: 2400,
+        start_date: "2017-01-30",
+        end_date: "2017-01-30",
       });
     });
   });

--- a/test/process_results/result_totals_calculator.test.js
+++ b/test/process_results/result_totals_calculator.test.js
@@ -30,6 +30,78 @@ describe("ResultTotalsCalculator", () => {
       });
     });
 
+    describe("when the report rows have a date dimension", () => {
+      let report;
+      let data;
+
+      const totalsForDates = (dates) => {
+        data.dimensionHeaders = [{ name: "date" }];
+        data.metricHeaders = [{ name: "totalUsers" }];
+        data.rows = dates.map((date) => {
+          return {
+            dimensionValues: [{ value: date }],
+            metricValues: [{ value: "10" }],
+          };
+        });
+
+        const analyticsData = AnalyticsData.fromGoogleAnalyticsQuery(
+          report.query,
+          [data],
+        )[0];
+        analyticsData.name = report.name;
+        analyticsData.processData(report);
+
+        return ResultTotalsCalculator.calculateTotals(analyticsData.toJSON());
+      };
+
+      beforeEach(() => {
+        report = Object.assign({}, reportFixture);
+        data = Object.assign({}, dataFixture);
+      });
+
+      it("sets start_date from the first row and end_date from the last", () => {
+        const totals = totalsForDates(["20170130", "20170131", "20170201"]);
+
+        expect(totals.start_date).to.equal("2017-01-30");
+        expect(totals.end_date).to.equal("2017-02-01");
+      });
+
+      it("skips a bogus (other) first row when setting start_date", () => {
+        const totals = totalsForDates(["(other)", "20170131", "20170201"]);
+
+        expect(totals.start_date).to.equal("2017-01-31");
+        expect(totals.end_date).to.equal("2017-02-01");
+      });
+    });
+
+    describe("when the report rows have no date dimension", () => {
+      it("does not set start_date or end_date", () => {
+        const report = Object.assign({}, reportFixture);
+        const data = Object.assign({}, dataFixture);
+        data.dimensionHeaders = [{ name: "browser" }];
+        data.metricHeaders = [{ name: "totalUsers" }];
+        data.rows = [
+          {
+            dimensionValues: [{ value: "Chrome" }],
+            metricValues: [{ value: "10" }],
+          },
+        ];
+
+        const analyticsData = AnalyticsData.fromGoogleAnalyticsQuery(
+          report.query,
+          [data],
+        )[0];
+        analyticsData.name = report.name;
+        analyticsData.processData(report);
+        const totals = ResultTotalsCalculator.calculateTotals(
+          analyticsData.toJSON(),
+        );
+
+        expect(totals).to.not.have.property("start_date");
+        expect(totals).to.not.have.property("end_date");
+      });
+    });
+
     describe("when the report data is not empty", () => {
       let totals;
       let report;


### PR DESCRIPTION
There are two bugs in the start/end date block in `src/process_results/result_totals_calculator.js`, and they hide each other, so they have to be fixed together.

The guard is `if (result.data[0].data)`. Result rows don't have a `data` key, they have `date` plus the metric keys, so the guard is always false and `start_date` / `end_date` are never set. Right inside that branch, `result.date[0].date` should be `result.data[0].date`. `result.date` is undefined, so if the guard ever passed, this would throw.

That's why fixing only the guard is worse than leaving it alone: it turns a silent no-op into a TypeError. I checked this rather than assuming it. Correcting the guard on its own takes the suite from 1 pre-existing failure to 19, all `TypeError: Cannot read properties of undefined (reading '0')`.

On intent, I didn't want to guess, so I traced it. Both typos came in together in 55a6f79, when this moved out of `process-ga-data.js`. The code before that move was:

```js
if ((result.data.length > 0) && (result.data[0].date)) {
    if (result.data[0].date == "(other)")
        result.totals.start_date = result.data[1].date;
    ...
```

So `result.data[0].date` in both spots is the original behavior, and the `result.data.length > 0` part is already covered by the early return at the top of `calculateTotals`. This restores that and nothing more.

One knock-on: `test/actions/query_google_analytics.test.js` asserted a totals object with no dates in it. That fixture is 24 hourly rows all on 20170130, so it now gets `start_date` and `end_date` of `2017-01-30`. I updated the expectation. Happy to hear if any consumer would rather not see these fields appear, since they've effectively been absent for years.

Tests added in `test/process_results/result_totals_calculator.test.js`: dates set from first and last row, a `(other)` first row skipped in favor of row 1, and rows with no date dimension still not getting the fields.

Verified on Node 22 (per `.nvmrc`) with `NODE_ENV=test npx mocha`:

- before: 212 passing, 1 failing
- both bugs reverted, new tests in place: 213 passing, 3 failing (the 2 new date tests plus the pre-existing one)
- guard fixed, typo left in: 174 passing, 19 failing, all TypeError
- with this change: 215 passing, 1 failing

The one constant failure is `PostgresPublisher`, which is `ECONNREFUSED` against a database I don't have locally. It fails identically on an unmodified checkout. `npx eslint .` and `prettier --check` are both clean.
