### PR TITLE
Use TLS for connection to egress proxy

### DIFF
--- a/README.md
+++ b/README.md
@@ -442,7 +442,7 @@ cf bind-service analytics-reporter-consumer analytics-reporter-database
 cf unbind-security-group public_networks_egress gsa-opp-analytics analytics-dev --lifecycle running
 
 # Create a network policy in the application's space which allows communication to the egress proxy which runs in a space with public egress permissions
-cf add-network-policy analytics-reporter-consumer analytics-egress-proxy -s analytics-public-egress -o gsa-opp-analytics --protocol tcp --port 8080
+cf add-network-policy analytics-reporter-production-consumer analytics-egress-proxy-prd -s analytics-public-egress -o gsa-opp-analytics --protocol tcp --port 61443
 
 
 # Create a network policy in the public-egress space which allows communication from the egress proxy back to the application.

--- a/deploy/consumer.js
+++ b/deploy/consumer.js
@@ -15,7 +15,7 @@ if (
   const credentials = encodeURI(
     `${process.env.PROXY_USERNAME}:${process.env.PROXY_PASSWORD}`,
   );
-  const proxy_url = `http://${credentials}@${process.env.PROXY_FQDN}:${process.env.PROXY_PORT}`;
+  const proxy_url = `https://${credentials}@${process.env.PROXY_FQDN}:${process.env.PROXY_PORT}`;
   // Setting this env var is a standard way to enable proxying for HTTP client
   // libraries.
   process.env.HTTPS_PROXY = proxy_url;


### PR DESCRIPTION
Use [secure container-to-container networking](https://docs.cloud.gov/platform/management/container-to-container/#configuring-secure-container-to-container-networking) between the reporter and the egress proxy.

Accompanying configuration changes:

- Set PROXY_PORT env variable to 61443
- `cf add-network-policy` with the new port
- `cf remove-network-policy` for the existing policy that uses 8080