### PR TITLE
Revert "Use TLS for connection to egress proxy (#1095)"

### DIFF
--- a/README.md
+++ b/README.md
@@ -442,7 +442,7 @@ cf bind-service analytics-reporter-consumer analytics-reporter-database
 cf unbind-security-group public_networks_egress gsa-opp-analytics analytics-dev --lifecycle running
 
 # Create a network policy in the application's space which allows communication to the egress proxy which runs in a space with public egress permissions
-cf add-network-policy analytics-reporter-production-consumer analytics-egress-proxy-prd -s analytics-public-egress -o gsa-opp-analytics --protocol tcp --port 61443
+cf add-network-policy analytics-reporter-consumer analytics-egress-proxy -s analytics-public-egress -o gsa-opp-analytics --protocol tcp --port 8080
 
 
 # Create a network policy in the public-egress space which allows communication from the egress proxy back to the application.

--- a/deploy/consumer.js
+++ b/deploy/consumer.js
@@ -15,7 +15,7 @@ if (
   const credentials = encodeURI(
     `${process.env.PROXY_USERNAME}:${process.env.PROXY_PASSWORD}`,
   );
-  const proxy_url = `https://${credentials}@${process.env.PROXY_FQDN}:${process.env.PROXY_PORT}`;
+  const proxy_url = `http://${credentials}@${process.env.PROXY_FQDN}:${process.env.PROXY_PORT}`;
   // Setting this env var is a standard way to enable proxying for HTTP client
   // libraries.
   process.env.HTTPS_PROXY = proxy_url;


### PR DESCRIPTION
This reverts commit 4f40a5cc0ce8e6f652bb6fb82eba0e891e084161.

Reverting because this did not work when tested in the dev Cloud.gov environment.

Apparently, gRPC implementations tend not to support TLS between the client and an http proxy. The JS client libraries that we use to call the Google Analytics Data API are all gRPC-based.

Evidence that `grpc-js` does not work with an https-enabled proxy:

- This still open [feature request](https://github.com/grpc/grpc-node/issues/1295).
- These [lines in the code](https://github.com/grpc/grpc-node/blob/651cbeec6b4d6d11cbee91c042946d2fe5968ef6/packages/grpc-js/src/http_proxy.ts#L76) that disable the proxy if it uses `https`.
- Observed behavior - after deploying this to Cloud.gov, the calls to *.googleapis.com started to be rejected with ECONNREFUSED errors, which would be expected if the gRPC libraries silently decided not to route through the proxy. I also saw the '"https:" scheme not supported in proxy URI' error in the logs.