### PR TITLE
Configure New Relic to use egress proxy, differently

### DIFF
--- a/newrelic.js
+++ b/newrelic.js
@@ -1,10 +1,7 @@
 exports.config = {
   app_name: [process.env.NEW_RELIC_APP_NAME],
   license_key: process.env.NEW_RELIC_LICENSE_KEY,
-  proxy_host: process.env.PROXY_FQDN,
-  proxy_port: process.env.PROXY_PORT,
-  proxy_user: process.env.PROXY_USERNAME,
-  proxy_pass: process.env.PROXY_PASSWORD,
+  proxy: `http://${process.env.PROXY_USERNAME}:${process.env.PROXY_PASSWORD}@${process.env.PROXY_FQDN}:${process.env.PROXY_PORT}`,
   logging: {
     level: "info",
     filepath: "stdout",


### PR DESCRIPTION
To fixed logged error:

> Your proxy server appears to be configured to accept connections over http. When setting `proxy_host` and `proxy_port` New Relic attempts to connect over SSL(https). If your proxy is configured to accept connections over http, try setting `proxy` to a fully qualified URL(e.g http://proxy-host:8080).